### PR TITLE
[WIP] trying to use cf-dockerized-buildpack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 node_modules/
 npm-debug.log
-out/*.conf
+nginx.conf
+.build/
+todo.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
-FROM nginx:1.11.10
+FROM cloud-gov/staticfile
 
-COPY out/nginx.docker.conf /etc/nginx/nginx.conf
+# COPY out/nginx.docker.conf /etc/nginx/nginx.conf

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,14 @@
 
 all: docker
 
-.PHONY: docker-nginx.conf docker clean
-
-docker-nginx.conf:
-	node build-config.js --docker
-
-docker: docker-nginx.conf
-	docker-compose build
+.PHONY: docker clean
 
 clean:
 	rm out/*.conf
+
+docker:
+	./build-cf-docker.sh
+	node build-config.js
+
+	# TODO: this isn't working :(
+	docker-compose build

--- a/build-cf-docker.sh
+++ b/build-cf-docker.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -e
+
+# Use a specific revision sha/branch/tag that is known to work since
+# cf-dockerized-buildpack is under development
+TARGET_REVISION=f3c07fcf09ca913850cd8f81dde4e993b0d1ab27
+
+CLONE_DIR=.build/cf-dockerized-buildpack
+
+if [ ! -d "$CLONE_DIR" ]; then
+  # Control will enter here if $DIRECTORY doesn't exist.
+  echo "-- Cloning 18F/cf-dockerized-buildpack to $CLONE_DIR."
+  git clone https://github.com/18F/cf-dockerized-buildpack.git .build/cf-dockerized-buildpack
+else
+  echo "-- Found $CLONE_DIR, continuing."
+fi
+
+cd .build/cf-dockerized-buildpack
+
+git checkout -q $TARGET_REVISION
+
+echo "-- Building staticfile buildpack docker image."
+./build.sh staticfile

--- a/build-config.js
+++ b/build-config.js
@@ -3,15 +3,12 @@ const fs = require('fs');
 const path = require('path');
 
 const nunjucks = require('nunjucks');
-const argv = require('minimist')(process.argv.slice(2));
 
 const lib = require('./lib');
 
 const PAGES_FILE = 'pages.yml';
 const NGINX_TEMPLATE_FILE = 'nginx.conf.nj';
-const NGINX_OUT_FILE = 'nginx.conf';
-const NGINX_OUT_PATH = './out';
-
+const NGINX_OUT_PATH = './';
 
 const contextDefaults = {
   PORT: '<%= ENV["PORT"] %>',
@@ -22,15 +19,10 @@ nunjucks.configure('templates', { autoescape: false });
 
 const localContext = {};
 
-if (argv.docker) {
-  localContext.IS_DOCKER = true;
-  localContext.PORT = 80;
-  console.log(`Building ${NGINX_OUT_FILE} in docker mode`);
-}
 
 const context = Object.assign({}, contextDefaults, localContext);
 
 const nginxConf = nunjucks.render(NGINX_TEMPLATE_FILE, context);
-const outFile = `nginx${argv.docker ? '.docker' : ''}.conf`;
+const outFile = 'nginx.conf';
 
 fs.writeFileSync(path.join(NGINX_OUT_PATH, outFile), nginxConf);

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,7 @@
 version: '2'
 services:
   app:
-    build: .
     ports:
-      - 8080:80
+      - 8080:8080
+    build:
+      context: .

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "eslint-plugin-import": "2.2.0",
     "faucet": "^0.0.1",
     "js-yaml": "^3.8.2",
-    "minimist": "^1.2.0",
     "nunjucks": "^3.0.0",
     "request": "^2.81.0",
     "tape": "^4.6.3"


### PR DESCRIPTION
This is a currently non-working attempt at using `https://github.com/18F/cf-dockerized-buildpack`.

Unfortunately, during [`docker-compose build`](https://github.com/18F/pages-redirects/pull/2/files#diff-b67911656ef5d18c4ae36cb6741b7965R14), this error is produced:

```
-----> Copying project files into public
       **ERROR** Unable to copy project files: rename /tmp/app/lib /home/vcap/tmp/staticfile-buildpack.approot.699603360/lib: invalid cross-device link
panic: rename /tmp/app/lib /home/vcap/tmp/staticfile-buildpack.approot.699603360/lib: invalid cross-device link

goroutine 1 [running]:
panic(0x6f6ea0, 0xc420012d40)
	/tmp/go/src/runtime/panic.go:500 +0x1a1
main.main()
	/tmp/buildpacks/3a1b5011afa99e7b2b34280d207b305c/src/compile/compile.go:58 +0x1ee
Failed to compile droplet
ERROR: Service 'app' failed to build: The command '/bin/sh -c /tmp/lifecycle/lifecycle-build.sh' returned a non-zero code: 223
```

which is coming from https://github.com/cloudfoundry/staticfile-buildpack/blob/7b401f7a84a36b9180af87deec9e2aeb4f2ccd31/src/compile/compile.go#L221