### PR TITLE
Remove test pages.yml configs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ services:
   - docker
 env:
   global:
-    - CF_CLI_VERSION=6.22.2
+    - CF_CLI_VERSION=6.25.0
 before_install:
   - npm install -g yarn
   - docker-compose --version

--- a/build-nginx-configs.js
+++ b/build-nginx-configs.js
@@ -7,7 +7,7 @@ const lib = require('./lib');
 const PAGES_FILE = 'pages.yml';
 const NGINX_OUT_PATH = './out';
 
-const pageConfigs = lib.getPageConfigs(PAGES_FILE);
+const pageConfigs = lib.getPageConfigs(fs.readFileSync(PAGES_FILE, 'utf-8'));
 const { dockerConf, prodConf } = lib.makeNginxConfigs(pageConfigs);
 
 fs.writeFileSync(path.join(NGINX_OUT_PATH, 'nginx.docker.conf'), dockerConf);

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,4 +1,3 @@
-const fs = require('fs');
 const yaml = require('js-yaml');
 const nunjucks = require('nunjucks');
 
@@ -7,8 +6,13 @@ nunjucks.configure('../templates', { autoescape: false });
 
 const NGINX_TEMPLATE_FILE = 'nginx.conf.nj';
 
-function getPageConfigs(configFile) {
-  const contents = yaml.safeLoad(fs.readFileSync(configFile, 'utf-8'));
+function getPageConfigs(yamlConfigString) {
+  const contents = yaml.safeLoad(yamlConfigString);
+
+  if (!contents || !contents.length) {
+    return [];
+  }
+
   const configs = contents.map((c) => {
     if (typeof c === 'string') {
       return { from: c, to: c };
@@ -20,6 +24,7 @@ function getPageConfigs(configFile) {
   });
   return configs;
 }
+
 
 function makeNginxConfigs(pageConfigs) {
   const defaultContext = {

--- a/pages.yml
+++ b/pages.yml
@@ -1,8 +1,6 @@
 ---
-- accessibility
-- agile
-- testing-cookbook
-- before-you-ship
-- guides
-- from: first-thing
-  to: other-thing
+# Add simple redirects with just
+# - pagename
+# Add redirects that have a change with
+# - from: oldname
+#   to: newname

--- a/test/integration/test_server.js
+++ b/test/integration/test_server.js
@@ -1,3 +1,4 @@
+const fs = require('fs');
 const path = require('path');
 const request = require('request');
 const test = require('tape');
@@ -16,7 +17,7 @@ test('host is running', (t) => {
   });
 });
 
-const pageConfigs = lib.getPageConfigs(PAGES_FILE);
+const pageConfigs = lib.getPageConfigs(fs.readFileSync(PAGES_FILE, 'utf-8'));
 pageConfigs.forEach((pc) => {
   test(`redirect "pages/${pc.from}" to "${pc.to}.18f.gov" works`, (t) => {
     const reqObj = { url: `${HOST}/${pc.from}`, followRedirect: false };

--- a/test/unit/test_lib.js
+++ b/test/unit/test_lib.js
@@ -1,18 +1,31 @@
-const path = require('path');
 const test = require('tape');
-
 
 const lib = require('../../lib');
 
-const PAGES_FILE = path.join(__dirname, 'test_pages_config.yml');
+const PAGES_CONFIG = [
+  '---',
+  '- test1',
+  '- test2',
+  '- from: test3from',
+  '  to: test3to',
+].join('\n');
+
+const EMTPY_CONFIG = '---\n';
 
 test('lib.getPageConfigs', (t) => {
-  const configs = lib.getPageConfigs(PAGES_FILE);
+  const configs = lib.getPageConfigs(PAGES_CONFIG);
   t.ok(configs);
   t.equal(configs.length, 3);
   t.same(configs[0], { to: 'test1', from: 'test1' });
   t.same(configs[1], { to: 'test2', from: 'test2' });
   t.same(configs[2], { to: 'test3to', from: 'test3from' });
+  t.end();
+});
+
+test('lib.getPageConfigs with empty config', (t) => {
+  const configs = lib.getPageConfigs(EMTPY_CONFIG);
+  t.ok(configs);
+  t.equal(configs.length, 0);
   t.end();
 });
 

--- a/test/unit/test_pages_config.yml
+++ b/test/unit/test_pages_config.yml
@@ -1,5 +1,0 @@
----
-- test1
-- test2
-- from: test3from
-  to: test3to


### PR DESCRIPTION
Closes #6 

I've also changed `getPageConfigs` to take a yaml-string instead of a file path. This allows better testing since I don't need to have a file to load.