### PR TITLE
Remove login.gov redirects

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,8 +24,6 @@ services:
       # These are all the `server_name`s that the nginx server is listening on
       - app:pif.gov
       - app:www.pif.gov
-      - app:login.gov
-      - app:www.login.gov
       - app:connect.gov
       - app:www.connect.gov
       - app:18f.gov

--- a/templates/_federalist-redirects.njk
+++ b/templates/_federalist-redirects.njk
@@ -9,14 +9,6 @@ server {
 
 server {
   listen {{ PORT }};
-  set $target_domain pages.18f.gov/identity-intro;
-  server_name login.gov www.login.gov;
-  add_header Strict-Transport-Security 'max-age=31536000; includeSubDomains; preload';
-  return 302 https://$target_domain$request_uri;
-}
-
-server {
-  listen {{ PORT }};
   set $target_domain login.gov;
   server_name connect.gov www.connect.gov;
   return 302 https://$target_domain$request_uri;

--- a/test/integration/test_federalist_redirects.js
+++ b/test/integration/test_federalist_redirects.js
@@ -5,8 +5,6 @@ const test = require('tape');
 const expectedRedirects = [
   { from: 'pif.gov', to: 'presidentialinnovationfellows.gov' },
   { from: 'www.pif.gov', to: 'presidentialinnovationfellows.gov' },
-  { from: 'login.gov', to: 'pages.18f.gov/identity-intro' },
-  { from: 'www.login.gov', to: 'pages.18f.gov/identity-intro' },
   { from: 'connect.gov', to: 'login.gov' },
   { from: 'www.connect.gov', to: 'login.gov' },
   { from: '18f.gov', to: '18f.gsa.gov' },


### PR DESCRIPTION
Closes #31 

Previously `login.gov` and `www.login.gov` would redirect to `pages.18f.gov/identity-intro`. This PR removes that redirection.