### PR TITLE
Add jobs.18f.gov route

### DIFF
--- a/templates/manifest-prod.yml.njk
+++ b/templates/manifest-prod.yml.njk
@@ -8,9 +8,8 @@ applications:
 instances: 4
 routes:
 - route: pages-redirects.app.cloud.gov
-- route: pages-staging.18f.gov  # TODO: change to pages.18f.gov when ready
-- route: guides-staging.18f.gov # TODO: change to guides.18f.gov when ready
 - route: join.18f.gov
+- route: jobs.18f.gov
 {% for page in PAGE_CONFIGS -%}
 - route: {{ page.to }}.{{ page.toDomain }}
 {% endfor -%}


### PR DESCRIPTION
Also remove pages-staging and guides-staging routes. They are unused.