### PR TITLE
Install yarn from apt

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ env:
   global:
     - CF_CLI_VERSION=6.25.0
 before_install:
-  - npm install -g yarn
+  - yarn --version
   - docker-compose --version
 install:
   - yarn --pure-lockfile

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,8 @@ before_install:
   - docker-compose --version
   - curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -
   - echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
-  - sudo apt-get update && sudo apt-get install yarn
+  - sudo apt-get -qq update && sudo apt-get -qq install yarn
+  - export PATH="$HOME/.yarn/bin:$PATH"
   - yarn --version
 install:
   - yarn --pure-lockfile

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ before_install:
   - echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
   - sudo apt-get -qq update && sudo apt-get -qq install yarn
   - export PATH="$HOME/.yarn/bin:$PATH"
-  - dpkg -L <packagename>
+  - dpkg -L yarn
   - yarn --version
 install:
   - yarn --pure-lockfile

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ before_install:
   - echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
   - sudo apt-get -qq update && sudo apt-get -qq install yarn
   - export PATH="$HOME/.yarn/bin:$PATH"
+  - dpkg -L <packagename>
   - yarn --version
 install:
   - yarn --pure-lockfile

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,11 @@ env:
   global:
     - CF_CLI_VERSION=6.25.0
 before_install:
-  - yarn --version
   - docker-compose --version
+  - curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -
+  - echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
+  - sudo apt-get update && sudo apt-get install yarn
+  - yarn --version
 install:
   - yarn --pure-lockfile
   - npm run build-docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,8 @@ before_install:
   - curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -
   - echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
   - sudo apt-get -qq update && sudo apt-get -qq install yarn
-  - export PATH="$HOME/.yarn/bin:$PATH"
-  - dpkg -L yarn
+  - export PATH="/usr/share/yarn/bin:$PATH"
+  - which yarn
   - yarn --version
 install:
   - yarn --pure-lockfile


### PR DESCRIPTION
This PR install yarn from apt, which is [recommended](https://yarnpkg.com/en/docs/install#linux-tab) over using `npm install -g yarn`.

I had tried using the "built-in" version of `yarn` that Travis already has, but it is a fairly old version (`0.17.8`). Current stable version is `0.23.2`.

Closes #38 