### PR TITLE
Run integration tests over https when TARGET_HOST is set

### DIFF
--- a/test/integration/test_federalist_redirects.js
+++ b/test/integration/test_federalist_redirects.js
@@ -2,10 +2,12 @@
 const request = require('request');
 const test = require('tape');
 
-// If we have a specified TARGET_HOST env var then we are testing against
-// a live server, which should be using https. Otherwise, we're testing
-// against our docker-compose setup, which will be on localhost over plain http.
-const PROTOCOL = process.env.TARGET_HOST ? 'https' : 'http';
+// If we have a specified TARGET_HOST env var that starts with 'https' then we
+// are testing against a live server, which should be using https.
+// Otherwise, we're testing against either localhost or our docker-compose setup,
+// which will over plain http.
+const PROTOCOL = process.env.TARGET_HOST && process.env.TARGET_HOST.startsWith('https')
+  ? 'https' : 'http';
 
 const expectedRedirects = [
   { from: 'pif.gov', to: 'presidentialinnovationfellows.gov' },

--- a/test/integration/test_federalist_redirects.js
+++ b/test/integration/test_federalist_redirects.js
@@ -2,6 +2,11 @@
 const request = require('request');
 const test = require('tape');
 
+// If we have a specified TARGET_HOST env var then we are testing against
+// a live server, which should be using https. Otherwise, we're testing
+// against our docker-compose setup, which will be on localhost over plain http.
+const PROTOCOL = process.env.TARGET_HOST ? 'https' : 'http';
+
 const expectedRedirects = [
   { from: 'pif.gov', to: 'presidentialinnovationfellows.gov' },
   { from: 'www.pif.gov', to: 'presidentialinnovationfellows.gov' },
@@ -16,7 +21,7 @@ const expectedRedirects = [
 ];
 
 function redirectOk(t, from, to) {
-  request({ url: `http://${from}`, followRedirect: false }, (err, res) => {
+  request({ url: `${PROTOCOL}://${from}`, followRedirect: false }, (err, res) => {
     t.notOk(err);
     t.ok(res);
     t.equal(res.statusCode, 302);


### PR DESCRIPTION
Fixes #48 

When `TARGET_HOST` is set and starts with `https`, then the integration tests are being run against a real server. This PR adjusts the test requests to use `https` in that case.