### PR TITLE
Fix to make the nginx config agnostic to pages.yml order

### DIFF
--- a/templates/nginx.conf.njk
+++ b/templates/nginx.conf.njk
@@ -40,7 +40,7 @@ http {
 
     # -- Redirects for pages.18f.gov sites
     {% for page in PAGE_CONFIGS %}
-    rewrite ^/{{ page.from }}(.*)$ https://{{ page.to }}.{{ page.toDomain }}$1;
+    rewrite ^/{{ page.from }}(\/.*)?$ https://{{ page.to }}.{{ page.toDomain }}$1;
     {% endfor %}
     # -- end redirects for pages.18f.gov sites
 

--- a/test/unit/test_lib.js
+++ b/test/unit/test_lib.js
@@ -46,7 +46,7 @@ test('lib.makeNginxConfigs', (t) => {
   t.ok(prodConf);
 
   TEST_PAGE_CONFIGS.forEach((pc) => {
-    const rewrite = `rewrite ^/${pc.from}(.*)$ https://${pc.to}.${pc.toDomain}$1;`;
+    const rewrite = `rewrite ^/${pc.from}(\\/.*)?$ https://${pc.to}.${pc.toDomain}$1;`;
     t.ok(prodConf.indexOf(rewrite) >= 0);
     t.ok(dockerConf.indexOf(rewrite) >= 0);
   });


### PR DESCRIPTION
Updates the `nginx.conf` template to require a leading slash before a subpath, if any, to help prevent a shorter domain eating a larger.  For example, with the previous template, an entry in `pages.yml` that just says `agile` would also generate this config line:

```
rewrite ^/agile(.*)$ https://agile.18f.gov$1;
```

This would also match `/agile-labor-categories`, which would then result in an incorrect redirect, on two fronts.  First, it would redirect to `agile.18f.gov` instead of `agile-labor-categories.18f.gov`.  Second, it would match the latter part as a subpath (`-labor-categories`) and append that, making the new whole redirect `https://agile.18f.gov-labor-categories`).

This PR updates the config such that the subpath is still optional, but if present, it must include a leading slash.  Now the output config looks like this:

```
rewrite ^/agile(\/.*)?$ https://agile.18f.gov$1;
```

This line no longer matches `/agile-labor-categories`, so nginx will then proceed to the next rule.

Issue was first identified here: https://github.com/18F/pages-redirects/pull/55#pullrequestreview-34963788