### PR TITLE
[needs review] remove guides and treat as any other app

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,4 +33,3 @@ services:
       - app:jobs.18f.gov
       - app:join.18f.gov
       - app:pages.18f.gov
-      - app:guides.18f.gov

--- a/pages.yml
+++ b/pages.yml
@@ -27,6 +27,7 @@
 - frontend
 - govconnect
 - guides-template
+- guides
 - partnership-playbook
 - plain-language-tutorial
 - product-guide

--- a/templates/manifest-prod.yml.njk
+++ b/templates/manifest-prod.yml.njk
@@ -14,7 +14,6 @@ routes:
 - route: www.pif.gov
 - route: connect.gov
 - route: www.connect.gov
-- route: guides.18f.gov
 - route: pages.18f.gov
 - route: app.gov
 - route: www.app.gov

--- a/templates/nginx.conf.njk
+++ b/templates/nginx.conf.njk
@@ -36,7 +36,7 @@ http {
 
   server {
     listen {{ PORT }};
-    server_name pages.18f.gov
+    server_name pages.18f.gov;
 
     # -- Redirects for pages.18f.gov sites
     {% for page in PAGE_CONFIGS %}

--- a/templates/nginx.conf.njk
+++ b/templates/nginx.conf.njk
@@ -36,7 +36,7 @@ http {
 
   server {
     listen {{ PORT }};
-    server_name pages.18f.gov guides.18f.gov;
+    server_name pages.18f.gov
 
     # -- Redirects for pages.18f.gov sites
     {% for page in PAGE_CONFIGS %}
@@ -49,7 +49,7 @@ http {
     rewrite ^/intake/.* https://18f.gsa.gov/contact/ redirect;
     rewrite ^/designstandards/.* https://standards.usa.gov/ redirect;
     rewrite ^/joining-18f/.* https://18f.gsa.gov/join/ redirect;
-    rewrite ^/$ /guides/ redirect;
+    rewrite ^/$ https://guides.18f.gov redirect;
     # -- end custom pages.18f.gov redirects
 
     # For everything else, proxy to the old Federalist bucket.

--- a/test/integration/test_pages_redirects.js
+++ b/test/integration/test_pages_redirects.js
@@ -13,15 +13,6 @@ function internalRedirectOk(t, res, internalPath) {
   t.equal(res.headers.location, `${HOST.replace('https', 'http')}/${internalPath}`);
 }
 
-test('redirects "/" to guides', (t) => {
-  const reqObj = { url: HOST, followRedirect: false };
-  request(reqObj, (err, res) => {
-    t.notOk(err);
-    internalRedirectOk(t, res, 'guides/');
-    t.end();
-  });
-});
-
 const pageConfigs = lib.getPageConfigs(fs.readFileSync(PAGES_FILE, 'utf-8'));
 pageConfigs.forEach((pc) => {
   test(`redirect "pages/${pc.from}" to "${pc.to}.18f.gov" works`, (t) => {

--- a/test/integration/test_pages_redirects.js
+++ b/test/integration/test_pages_redirects.js
@@ -13,6 +13,16 @@ function internalRedirectOk(t, res, internalPath) {
   t.equal(res.headers.location, `${HOST.replace('https', 'http')}/${internalPath}`);
 }
 
+test('redirects "/" to guides.18f.gov', (t) => {
+  const reqObj = { url: HOST, followRedirect: false };
+  request(reqObj, (err, res) => {
+    t.notOk(err);
+    t.equal(res.statusCode, 302);
+    t.equal(res.headers.location, 'https://guides.18f.gov');
+    t.end();
+  });
+});
+
 const pageConfigs = lib.getPageConfigs(fs.readFileSync(PAGES_FILE, 'utf-8'));
 pageConfigs.forEach((pc) => {
   test(`redirect "pages/${pc.from}" to "${pc.to}.18f.gov" works`, (t) => {


### PR DESCRIPTION
Context: https://github.com/18F/guides/issues/51

After this, guides.18f.gov should act like any other redirect