### PR TITLE
Add hostname to redirects for non-migrated pages w/o a trailing slash

### DIFF
--- a/templates/nginx.conf.njk
+++ b/templates/nginx.conf.njk
@@ -55,7 +55,7 @@ http {
     # For everything else, proxy to the old Federalist bucket.
     # This portion will go away soon once all 18F pages are migrated to their
     # new subdomain homes.
-    rewrite ^/([^/]*)$ /$1/ redirect; # add trailing slash if missing
+    rewrite ^/([^/]*)$ https://pages.18f.gov/$1/ redirect; # add trailing slash if missing
     location / {
       # proxy everything else to the old Federalist S3 bucket
       proxy_pass http://federalist.18f.gov.s3-website-us-east-1.amazonaws.com/site/18f/;

--- a/test/integration/test_pages_redirects.js
+++ b/test/integration/test_pages_redirects.js
@@ -8,11 +8,6 @@ const lib = require('../../lib');
 const HOST = process.env.TARGET_HOST || 'http://localhost:8080';
 const PAGES_FILE = path.join(__dirname, '../..', 'pages.yml');
 
-function internalRedirectOk(t, res, internalPath) {
-  t.equal(res.statusCode, 302);
-  t.equal(res.headers.location, `${HOST.replace('https', 'http')}/${internalPath}`);
-}
-
 test('redirects "/" to guides.18f.gov', (t) => {
   const reqObj = { url: HOST, followRedirect: false };
   request(reqObj, (err, res) => {
@@ -53,7 +48,8 @@ test('proxy_pass for non-migrated pages works', (t) => {
   const reqObj = { url: `${HOST}/non-migrated-page`, followRedirect: false };
   request(reqObj, (err, res) => {
     t.notOk(err);
-    internalRedirectOk(t, res, 'non-migrated-page/');
+    t.equal(res.statusCode, 302);
+    t.equal(res.headers.location, 'https://pages.18f.gov/non-migrated-page/');
     t.end();
   });
 });


### PR DESCRIPTION
Pages without a trailing slash are supposed to redirect to the page with a trailing slash. For example `page.18f.gov/lean-product-design` should redirect to `pages.18f.gov/lean-product-design`.

Unfortunatly, the redirect above was pointing to `pages-redirects.apps.cloud.gov/lean-product-design` since there was no hostname in the target for the rewrite. This commit adds a hostname to the target.