### PR TITLE
Redirect identity-dev-docs to developers.login.gov

### DIFF
--- a/templates/nginx.conf.njk
+++ b/templates/nginx.conf.njk
@@ -49,6 +49,7 @@ http {
     rewrite ^/intake/.* https://18f.gsa.gov/contact/ redirect;
     rewrite ^/designstandards/.* https://standards.usa.gov/ redirect;
     rewrite ^/joining-18f/.* https://18f.gsa.gov/join/ redirect;
+    rewrite ^/identity-dev-docs/.* https://developers.login.gov/ redirect;
     rewrite ^/$ https://guides.18f.gov redirect;
     # -- end custom pages.18f.gov redirects
 


### PR DESCRIPTION
For https://github.com/18F/identity-private/issues/2009.

Please do not make this live until https://developers.login.gov/ works.