### PR TITLE
Change redirects to 301 (Moved Permanently)

### DIFF
--- a/templates/_federalist-redirects.njk
+++ b/templates/_federalist-redirects.njk
@@ -4,14 +4,14 @@ server {
   listen {{ PORT }};
   set $target_domain presidentialinnovationfellows.gov;
   server_name pif.gov www.pif.gov;
-  return 302 https://$target_domain$request_uri;
+  return 301 https://$target_domain$request_uri;
 }
 
 server {
   listen {{ PORT }};
   set $target_domain login.gov;
   server_name connect.gov www.connect.gov;
-  return 302 https://$target_domain$request_uri;
+  return 301 https://$target_domain$request_uri;
 }
 
 server {
@@ -20,25 +20,25 @@ server {
   server_name 18f.gov www.18f.gov;
   add_header X-Government-Innovation Disrupted;
   add_header Strict-Transport-Security 'max-age=31536000; includeSubDomains; preload';
-  return 302 https://$target_domain$request_uri;
+  return 301 https://$target_domain$request_uri;
 }
 
 server {
   listen {{ PORT }};
   set $target_domain apps.gov;
   server_name app.gov www.app.gov;
-  return 302 https://$target_domain$request_uri;
+  return 301 https://$target_domain$request_uri;
 }
 
 server {
   listen {{ PORT }};
   set $target_domain join.18f.gov;
   server_name jobs.18f.gov;
-  return 302 https://$target_domain$request_uri;
+  return 301 https://$target_domain$request_uri;
 }
 
 server {
   listen {{ PORT }};
   server_name join.18f.gov;
-  return 302 https://18f.gsa.gov/join/;
+  return 301 https://18f.gsa.gov/join/;
 }

--- a/templates/nginx.conf.njk
+++ b/templates/nginx.conf.njk
@@ -40,7 +40,7 @@ http {
 
     # -- Redirects for pages.18f.gov sites
     {% for page in PAGE_CONFIGS %}
-    rewrite ^/{{ page.from }}(\/.*)?$ https://{{ page.to }}.{{ page.toDomain }}{{ page.toPath }}$1;
+    rewrite ^/{{ page.from }}(\/.*)?$ https://{{ page.to }}.{{ page.toDomain }}{{ page.toPath }}$1 permanent;
     {% endfor %}
     # -- end redirects for pages.18f.gov sites
 

--- a/test/integration/test_federalist_redirects.js
+++ b/test/integration/test_federalist_redirects.js
@@ -26,7 +26,7 @@ function redirectOk(t, from, to) {
   request({ url: `${PROTOCOL}://${from}`, followRedirect: false }, (err, res) => {
     t.notOk(err);
     t.ok(res);
-    t.equal(res.statusCode, 302);
+    t.equal(res.statusCode, 301);
     t.equal(res.headers.location, `https://${to}`);
     t.end();
   });

--- a/test/integration/test_pages_redirects.js
+++ b/test/integration/test_pages_redirects.js
@@ -12,7 +12,7 @@ test('redirects "/" to guides.18f.gov', (t) => {
   const reqObj = { url: HOST, followRedirect: false };
   request(reqObj, (err, res) => {
     t.notOk(err);
-    t.equal(res.statusCode, 302);
+    t.equal(res.statusCode, 301);
     t.equal(res.headers.location, 'https://guides.18f.gov');
     t.end();
   });
@@ -31,7 +31,7 @@ subdomainConfigs.forEach((pc) => {
     };
     request(reqObj, (err, res) => {
       t.notOk(err);
-      t.equal(res.statusCode, 302);
+      t.equal(res.statusCode, 301);
       t.equal(res.headers.location, `https://${pc.to}.18f.gov`);
       t.end();
     });
@@ -41,7 +41,7 @@ subdomainConfigs.forEach((pc) => {
     const reqObj = { url: `${HOST}/${pc.from}/subpath`, followRedirect: false };
     request(reqObj, (err, res) => {
       t.notOk(err);
-      t.equal(res.statusCode, 302);
+      t.equal(res.statusCode, 301);
       t.equal(res.headers.location, `https://${pc.to}.18f.gov/subpath`);
       t.end();
     });
@@ -56,7 +56,7 @@ customDomainConfigs.forEach((pc) => {
     };
     request(reqObj, (err, res) => {
       t.notOk(err);
-      t.equal(res.statusCode, 302);
+      t.equal(res.statusCode, 301);
       t.equal(res.headers.location, `https://${pc.to}.${pc.toDomain}${pc.toPath}`);
       t.end();
     });
@@ -66,7 +66,7 @@ customDomainConfigs.forEach((pc) => {
     const reqObj = { url: `${HOST}/${pc.from}/subpath`, followRedirect: false };
     request(reqObj, (err, res) => {
       t.notOk(err);
-      t.equal(res.statusCode, 302);
+      t.equal(res.statusCode, 301);
       t.equal(res.headers.location, `https://${pc.to}.${pc.toDomain}${pc.toPath}/subpath`);
       t.end();
     });
@@ -84,7 +84,7 @@ customDomainConfigs.forEach((pc) => {
     const reqObj = { url: `${HOST}/${from}`, followRedirect: false };
     request(reqObj, (err, res) => {
       t.notOk(err);
-      t.equal(res.statusCode, 302);
+      t.equal(res.statusCode, 301);
       t.equal(res.headers.location, `https://${to}`);
       t.end();
     });
@@ -95,7 +95,7 @@ test('proxy_pass for non-migrated pages works', (t) => {
   const reqObj = { url: `${HOST}/non-migrated-page`, followRedirect: false };
   request(reqObj, (err, res) => {
     t.notOk(err);
-    t.equal(res.statusCode, 302);
+    t.equal(res.statusCode, 301);
     t.equal(res.headers.location, 'https://pages.18f.gov/non-migrated-page/');
     t.end();
   });

--- a/test/unit/test_lib.js
+++ b/test/unit/test_lib.js
@@ -51,7 +51,7 @@ test('lib.makeNginxConfigs', (t) => {
   t.ok(prodConf);
 
   TEST_PAGE_CONFIGS.forEach((pc) => {
-    const rewrite = `rewrite ^/${pc.from}(\\/.*)?$ https://${pc.to}.${pc.toDomain}$1;`;
+    const rewrite = `rewrite ^/${pc.from}(\\/.*)?$ https://${pc.to}.${pc.toDomain}$1 permanent;`;
     t.ok(prodConf.indexOf(rewrite) >= 0);
     t.ok(dockerConf.indexOf(rewrite) >= 0);
   });


### PR DESCRIPTION
Since the URLs have changed permanently, this should help with SEO

From StackOverflow:

> Status 301 means that the resource (page) is moved permanently to a new location. The client/browser should not attempt to request the original location but use the new location from now on.
> 
> Status 302 means that the resource is temporarily located somewhere else, and the client/browser should continue requesting the original url.


http://stackoverflow.com/a/1393298

My understanding is that we're never going to use the old-style pages.18f.gov URLs again, so wherever these are moving to is permanent.