### PR TITLE
Show an error page for any request not covered by a redirect

### DIFF
--- a/templates/nginx.conf.njk
+++ b/templates/nginx.conf.njk
@@ -56,7 +56,7 @@ http {
     location / {
       # Return a not found error
       return 404 "<h1>Page Not Found</h1>
-                  <p>If this request was for a site previously on 18F Pages
+                  <p>If you are looking for a site previously on 18F Pages
                     that you think should still exist, please send a message to
                     <a href='mailto:federalist-support@gsa.gov'>federalist-support@gsa.gov</a>.
                   </p>";

--- a/templates/nginx.conf.njk
+++ b/templates/nginx.conf.njk
@@ -52,13 +52,15 @@ http {
     rewrite ^/$ https://guides.18f.gov redirect;
     # -- end custom pages.18f.gov redirects
 
-    # For everything else, proxy to the old Federalist bucket.
-    # This portion will go away soon once all 18F pages are migrated to their
-    # new subdomain homes.
-    rewrite ^/([^/]*)$ https://pages.18f.gov/$1/ redirect; # add trailing slash if missing
+    # For everything else, show an error message
     location / {
-      # proxy everything else to the old Federalist S3 bucket
-      proxy_pass http://federalist.18f.gov.s3-website-us-east-1.amazonaws.com/site/18f/;
+      # Return a not found error
+      return 404 "<h1>Page Not Found</h1>
+                  <p>If this request was for a site previously on 18F Pages
+                    that you think should still exist, please send a message to
+                    <a href='mailto:federalist-support@gsa.gov'>federalist-support@gsa.gov</a>.
+                  </p>";
+      default_type text/html;
     }
   }
 

--- a/test/integration/test_pages_redirects.js
+++ b/test/integration/test_pages_redirects.js
@@ -91,12 +91,13 @@ customDomainConfigs.forEach((pc) => {
   });
 });
 
-test('proxy_pass for non-migrated pages works', (t) => {
+test('return error page for anything else', (t) => {
   const reqObj = { url: `${HOST}/non-migrated-page`, followRedirect: false };
   request(reqObj, (err, res) => {
     t.notOk(err);
-    t.equal(res.statusCode, 302);
-    t.equal(res.headers.location, 'https://pages.18f.gov/non-migrated-page/');
+    t.equal(res.statusCode, 404);
+    t.ok(res.body.indexOf('federalist-support@gsa.gov') > -1, 'contains support email address');
+    t.equal(res.headers['content-type'], 'text/html; charset=utf-8');
     t.end();
   });
 });


### PR DESCRIPTION
All 18F Pages have now been migrated and Federalist is moving from E/W to GovCloud, so the old S3 bucket will soon be shut down.

The error page is very simple. It looks like this:

<img width="914" alt="screen shot 2017-05-25 at 2 23 22 pm" src="https://cloud.githubusercontent.com/assets/697848/26466905/1101ebae-4156-11e7-9b25-9ea6ef5b1aa1.png">

