### PR TITLE
Remove old fec-style guide

### DIFF
--- a/pages.yml
+++ b/pages.yml
@@ -26,7 +26,6 @@
 - design-principles-guide
 - digitalaccelerator
 - digital-acquisition-playbook
-- fec-style
 - federalist-modern-team-template
 - from: fedspendingtransparency.github.io
   to: fedspendingtransparency


### PR DESCRIPTION
This changeset removes the redirect to `fec-style` is that is now an old guide that we will not be publishing via pages anymore.  The new guide is hosted on cloud.gov.