### PR TITLE
Make rewrite regex case-insensitive

### DIFF
--- a/pages.yml
+++ b/pages.yml
@@ -15,7 +15,6 @@
 - agile-labor-categories
 - agile
 - api-all-the-x
-- API-All-the-X
 - api-program
 - api-usability-testing
 - automated-testing-playbook

--- a/templates/nginx.conf.njk
+++ b/templates/nginx.conf.njk
@@ -40,7 +40,7 @@ http {
 
     # -- Redirects for pages.18f.gov sites
     {% for page in PAGE_CONFIGS %}
-    rewrite ^/{{ page.from }}(\/.*)?$ https://{{ page.to }}.{{ page.toDomain }}{{ page.toPath }}$1;
+    rewrite (?i)^/{{ page.from }}(\/.*)?$ https://{{ page.to }}.{{ page.toDomain }}{{ page.toPath }}$1;
     {% endfor %}
     # -- end redirects for pages.18f.gov sites
 

--- a/test/integration/test_pages_redirects.js
+++ b/test/integration/test_pages_redirects.js
@@ -20,35 +20,8 @@ test('redirects "/" to guides.18f.gov', (t) => {
 
 const pageConfigs = lib.getPageConfigs(fs.readFileSync(PAGES_FILE, 'utf-8'));
 
-const subdomainConfigs = pageConfigs.filter(pc => !pc.toDomain);
-const customDomainConfigs = pageConfigs.filter(pc => pc.toDomain);
 
-subdomainConfigs.forEach((pc) => {
-  test(`redirect "pages/${pc.from}" to "${pc.to}.18f.gov" works`, (t) => {
-    const reqObj = {
-      url: `${HOST}/${pc.from}`,
-      followRedirect: false,
-    };
-    request(reqObj, (err, res) => {
-      t.notOk(err);
-      t.equal(res.statusCode, 302);
-      t.equal(res.headers.location, `https://${pc.to}.18f.gov`);
-      t.end();
-    });
-  });
-
-  test(`redirect "pages/${pc.from}/subpath" to "${pc.to}.18f.gov/subpath" works`, (t) => {
-    const reqObj = { url: `${HOST}/${pc.from}/subpath`, followRedirect: false };
-    request(reqObj, (err, res) => {
-      t.notOk(err);
-      t.equal(res.statusCode, 302);
-      t.equal(res.headers.location, `https://${pc.to}.18f.gov/subpath`);
-      t.end();
-    });
-  });
-});
-
-customDomainConfigs.forEach((pc) => {
+pageConfigs.forEach((pc) => {
   test(`redirect "pages/${pc.from}" to "${pc.to}.${pc.toDomain}" works`, (t) => {
     const reqObj = {
       url: `${HOST}/${pc.from}`,

--- a/test/unit/test_lib.js
+++ b/test/unit/test_lib.js
@@ -51,7 +51,7 @@ test('lib.makeNginxConfigs', (t) => {
   t.ok(prodConf);
 
   TEST_PAGE_CONFIGS.forEach((pc) => {
-    const rewrite = `rewrite ^/${pc.from}(\\/.*)?$ https://${pc.to}.${pc.toDomain}$1;`;
+    const rewrite = `rewrite (?i)^/${pc.from}(\\/.*)?$ https://${pc.to}.${pc.toDomain}$1;`;
     t.ok(prodConf.indexOf(rewrite) >= 0);
     t.ok(dockerConf.indexOf(rewrite) >= 0);
   });


### PR DESCRIPTION
so that requests of the form pages.18f.gov/CasedName will still work

Also:
- Remove now unnecessary "API-All-the-X" config
- Remove spurious tests from change in #75 that were never actually run