### PR TITLE
Redirect connect.gov to connect.ct.gov

### DIFF
--- a/templates/_federalist-redirects.njk
+++ b/templates/_federalist-redirects.njk
@@ -9,13 +9,6 @@ server {
 
 server {
   listen {{ PORT }};
-  set $target_domain login.gov;
-  server_name connect.gov www.connect.gov;
-  return 302 https://$target_domain$request_uri;
-}
-
-server {
-  listen {{ PORT }};
   set $target_domain 18f.gsa.gov;
   server_name 18f.gov www.18f.gov;
   add_header X-Government-Innovation Disrupted;

--- a/test/integration/test_federalist_redirects.js
+++ b/test/integration/test_federalist_redirects.js
@@ -12,8 +12,6 @@ const PROTOCOL = process.env.TARGET_HOST && process.env.TARGET_HOST.startsWith('
 const expectedRedirects = [
   { from: 'pif.gov', to: 'presidentialinnovationfellows.gov' },
   { from: 'www.pif.gov', to: 'presidentialinnovationfellows.gov' },
-  { from: 'connect.gov', to: 'login.gov' },
-  { from: 'www.connect.gov', to: 'login.gov' },
   { from: '18f.gov', to: '18f.gsa.gov' },
   { from: 'www.18f.gov', to: '18f.gsa.gov' },
   { from: 'app.gov', to: 'apps.gov' },


### PR DESCRIPTION
Lots of users looking for connect.ct.gov are confused when connect.gov
takes them to login.gov. We expect to eventually remove this redirect in
favor of a Federalist site explaining connect.gov to users and providing
them links to get where they want to go.