### PR TITLE
Adding redirect for the Partnership Principles

### DIFF
--- a/pages.yml
+++ b/pages.yml
@@ -54,7 +54,10 @@
 - open-source-guide
 - open-source-program
 - paid-leave-prototype
-- partnership-playbook
+- from: partnership-playbook
+  to: www
+  toDomain: 18f.gsa.gov
+  toPath: /partnership-principles
 - private-eye
 - plain-language-tutorial
 - product-guide

--- a/pages.yml
+++ b/pages.yml
@@ -55,7 +55,6 @@
 - open-source-program
 - paid-leave-prototype
 - from: partnership-playbook
-  to: www
   toDomain: 18f.gsa.gov
   toPath: /partnership-principles
 - private-eye


### PR DESCRIPTION
Redirect from `partnership-playbook.18f.gov` to `18f.gsa.gov/partnership-principles`