### PR TITLE
[HOLD] Redirect for digitalgov.gov domain

### DIFF
--- a/templates/_federalist-redirects.njk
+++ b/templates/_federalist-redirects.njk
@@ -35,3 +35,10 @@ server {
   server_name join.18f.gov;
   return 302 https://18f.gsa.gov/join/;
 }
+
+server {
+  listen {{ PORT }};
+  set $target_domain digitalgov.gov;
+  server_name www.digitalgov.gov;
+  return 302 https://$target_domain$request_uri;
+}

--- a/templates/_federalist-redirects.njk
+++ b/templates/_federalist-redirects.njk
@@ -42,3 +42,5 @@ server {
   server_name www.digitalgov.gov;
   return 302 https://$target_domain$request_uri;
 }
+
+


### PR DESCRIPTION
This is redirect is for `digitalgov.gov` to go to `www.digitalgov.gov`.

There is currently a federalist theme that does a redir on this root domain. This change (i hope) would change it to be a proper 302 redirect on `digitalgov.gov`

---

## ⚠️Before merging,...
- [ ] verify this, in no way, will affect any of the sub-domains on `digitalgov.gov`.
- [ ] notify @jeremyzilar when this will be happening

