### PR TITLE
[HOLD] 301 redirect from digitalgov.gov to digital.gov

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,3 +33,5 @@ services:
       - app:jobs.18f.gov
       - app:join.18f.gov
       - app:pages.18f.gov
+      - app:digitalgov.gov
+      - app:www.digitalgov.gov

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,3 +35,4 @@ services:
       - app:pages.18f.gov
       - app:digitalgov.gov
       - app:www.digitalgov.gov
+      - app:www.digital.gov

--- a/templates/_federalist-redirects.njk
+++ b/templates/_federalist-redirects.njk
@@ -40,6 +40,6 @@ server {
 server {
   listen {{ PORT }};
   set $target_domain digital.gov;
-  server_name digitalgov.gov www.digitalgov.gov;
+  server_name digitalgov.gov www.digitalgov.gov www.digital.gov;
   return 301 https://$target_domain$request_uri;
 }

--- a/templates/_federalist-redirects.njk
+++ b/templates/_federalist-redirects.njk
@@ -36,6 +36,7 @@ server {
   return 302 https://18f.gsa.gov/join/;
 }
 
+# DigitalGov.gov --> Digital.gov
 server {
   listen {{ PORT }};
   set $target_domain digital.gov;

--- a/templates/_federalist-redirects.njk
+++ b/templates/_federalist-redirects.njk
@@ -35,3 +35,10 @@ server {
   server_name join.18f.gov;
   return 302 https://18f.gsa.gov/join/;
 }
+
+server {
+  listen {{ PORT }};
+  set $target_domain digital.gov;
+  server_name digitalgov.gov www.digitalgov.gov;
+  return 301 https://$target_domain$request_uri;
+}

--- a/templates/manifest-prod.yml.njk
+++ b/templates/manifest-prod.yml.njk
@@ -21,6 +21,7 @@ routes:
 - route: www.18f.gov
 - route: digitalgov.gov
 - route: www.digitalgov.gov
+- route: www.digital.gov
 {% for page in PAGE_CONFIGS -%}
 - route: {{ page.to }}.{{ page.toDomain }}
 {% endfor -%}

--- a/templates/manifest-prod.yml.njk
+++ b/templates/manifest-prod.yml.njk
@@ -19,6 +19,8 @@ routes:
 - route: www.app.gov
 - route: 18f.gov
 - route: www.18f.gov
+- route: digitalgov.gov
+- route: www.digitalgov.gov
 {% for page in PAGE_CONFIGS -%}
 - route: {{ page.to }}.{{ page.toDomain }}
 {% endfor -%}


### PR DESCRIPTION
# 🚨HOLD

## What we're changing

We are redirecting `digitalgov.gov` and `www.digitalgov.gov` to ➡️ `digital.gov` with a 301 redirect.
We are hoping that all paths also resolve under the new `digital.gov` URL.
For example, `digitalgov.gov/events/` should redirect to `digital.gov/events/`

### Redirects we are putting in
- `digitalgov.gov` to `digital.gov`
- `www.digitalgov.gov` to `digital.gov`
- `www.digital.gov` to `digital.gov`

### Related DNS changes https://github.com/18F/dns/pull/231


_All PRs must receive approval from a member of the Federalist team._
