### PR TITLE
Test redirect for demo.digitalgov.gov

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,3 +33,4 @@ services:
       - app:jobs.18f.gov
       - app:join.18f.gov
       - app:pages.18f.gov
+      - app:demo.digitalgov.gov

--- a/templates/_federalist-redirects.njk
+++ b/templates/_federalist-redirects.njk
@@ -35,3 +35,10 @@ server {
   server_name join.18f.gov;
   return 302 https://18f.gsa.gov/join/;
 }
+
+server {
+  listen {{ PORT }};
+  set $target_domain demo.digital.gov;
+  server_name demo.digitalgov.gov;
+  return 302 https://$target_domain$request_uri;
+}

--- a/templates/manifest-prod.yml.njk
+++ b/templates/manifest-prod.yml.njk
@@ -19,6 +19,7 @@ routes:
 - route: www.app.gov
 - route: 18f.gov
 - route: www.18f.gov
+- route: demo.digitalgov.gov
 {% for page in PAGE_CONFIGS -%}
 - route: {{ page.to }}.{{ page.toDomain }}
 {% endfor -%}

--- a/test/integration/test_federalist_redirects.js
+++ b/test/integration/test_federalist_redirects.js
@@ -18,6 +18,7 @@ const expectedRedirects = [
   { from: 'www.app.gov', to: 'apps.gov' },
   { from: 'jobs.18f.gov', to: 'join.18f.gov' },
   { from: 'join.18f.gov', to: '18f.gsa.gov/join', noPath: true },
+  { from: 'demo.digitalgov.gov', to: 'demo.digital.gov' },
 ];
 
 function redirectOk(t, from, to) {


### PR DESCRIPTION
Before we launch https://github.com/18F/pages-redirects/pull/101
We are testing with a subdomain.

---

All PRs must receive approval from a member of the Federalist team.
