### PR TITLE
Redirect for openopps

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,3 +34,4 @@ services:
       - app:join.18f.gov
       - app:pages.18f.gov
       - app:demo.digitalgov.gov
+      - app:openopps.digitalgov.gov

--- a/templates/_federalist-redirects.njk
+++ b/templates/_federalist-redirects.njk
@@ -36,9 +36,18 @@ server {
   return 302 https://18f.gsa.gov/join/;
 }
 
+# Digital.gov —
 server {
   listen {{ PORT }};
   set $target_domain demo.digital.gov;
   server_name demo.digitalgov.gov;
+  return 302 https://$target_domain$request_uri;
+}
+
+# OpenOpps — Redirect openopps.digitalgov.gov to openopps.usajobs.gov
+server {
+  listen {{ PORT }};
+  set $target_domain openopps.usajobs.gov;
+  server_name openopps.digitalgov.gov;
   return 302 https://$target_domain$request_uri;
 }

--- a/test/integration/test_federalist_redirects.js
+++ b/test/integration/test_federalist_redirects.js
@@ -19,6 +19,7 @@ const expectedRedirects = [
   { from: 'jobs.18f.gov', to: 'join.18f.gov' },
   { from: 'join.18f.gov', to: '18f.gsa.gov/join', noPath: true },
   { from: 'demo.digitalgov.gov', to: 'demo.digital.gov' },
+  { from: 'openopps.digitalgov.gov', to: 'openopps.usajobs.gov' },
 ];
 
 function redirectOk(t, from, to) {


### PR DESCRIPTION
This will Redirect openopps.digitalgov.gov to openopps.usajobs.gov

All PRs must receive approval from a member of the Federalist team.
