### PR TITLE
Redirect blogging guides subdomain to handbook.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,3 +39,5 @@ services:
       - app:summit.digitalgov.gov
       - app:www.digital.gov
       - app:openopps.digitalgov.gov
+      - app:guides.18f.gov
+      - app:guides.18f.gsa.gov

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,5 +39,4 @@ services:
       - app:summit.digitalgov.gov
       - app:www.digital.gov
       - app:openopps.digitalgov.gov
-      - app:guides.18f.gov
-      - app:guides.18f.gsa.gov
+      - app:blogging-guide.18f.gov

--- a/pages.yml
+++ b/pages.yml
@@ -19,7 +19,6 @@
 - api-usability-testing
 - automated-testing-playbook
 - before-you-ship
-- blogging-guide
 - brand
 - content-guide
 - contracting-cookbook

--- a/templates/_federalist-redirects.njk
+++ b/templates/_federalist-redirects.njk
@@ -68,10 +68,11 @@ server {
   return 301 https://$target_domain$request_uri;
 }
 
-# guides.18f.gov to www.18f.gov/guides
+
+# blogging-guide.18f.gov to handbook.18f.gov/blogging
 server {
   listen {{ PORT }};
-  set $target_domain 18f.gov/guides;
-  server_name guides.18f.gov;
-  return 301 https://$target_domain$request_uri;
+  set $target_domain handbook.18f.gov/blogging;
+  server_name blogging-guide.18f.gov;
+  return 301 https://$target_domain;
 }

--- a/templates/_federalist-redirects.njk
+++ b/templates/_federalist-redirects.njk
@@ -67,3 +67,11 @@ server {
   server_name openopps.digitalgov.gov;
   return 301 https://$target_domain$request_uri;
 }
+
+# guides.18f.gov to www.18f.gov/guides
+server {
+  listen {{ PORT }};
+  set $target_domain 18f.gov/guides;
+  server_name guides.18f.gov;
+  return 301 https://$target_domain$request_uri;
+}

--- a/templates/manifest-prod.yml.njk
+++ b/templates/manifest-prod.yml.njk
@@ -25,6 +25,7 @@ routes:
 - route: summit.digitalgov.gov
 - route: www.digital.gov
 - route: openopps.digitalgov.gov
+- route: blogging-guide.18f.gov
 {% for page in PAGE_CONFIGS -%}
 - route: {{ page.to }}.{{ page.toDomain }}
 {% endfor -%}


### PR DESCRIPTION
Redirect blogging guides subdomain to handbook. We only need to redirect the domain not the URI request.