### PR TITLE
remove redirects for www.app.gov and app.gov

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,8 +28,6 @@ services:
       - app:www.connect.gov
       - app:18f.gov
       - app:www.18f.gov
-      - app:app.gov
-      - app:www.app.gov
       - app:jobs.18f.gov
       - app:join.18f.gov
       - app:pages.18f.gov

--- a/templates/_federalist-redirects.njk
+++ b/templates/_federalist-redirects.njk
@@ -18,13 +18,6 @@ server {
 
 server {
   listen {{ PORT }};
-  set $target_domain apps.gov;
-  server_name app.gov www.app.gov;
-  return 302 https://$target_domain$request_uri;
-}
-
-server {
-  listen {{ PORT }};
   set $target_domain join.18f.gov;
   server_name jobs.18f.gov;
   return 302 https://$target_domain$request_uri;

--- a/templates/manifest-prod.yml.njk
+++ b/templates/manifest-prod.yml.njk
@@ -15,8 +15,6 @@ routes:
 - route: connect.gov
 - route: www.connect.gov
 - route: pages.18f.gov
-- route: app.gov
-- route: www.app.gov
 - route: 18f.gov
 - route: www.18f.gov
 - route: digitalgov.gov

--- a/test/integration/test_federalist_redirects.js
+++ b/test/integration/test_federalist_redirects.js
@@ -14,8 +14,6 @@ const expectedRedirects = [
   { from: 'www.pif.gov', to: 'presidentialinnovationfellows.gov' },
   { from: '18f.gov', to: '18f.gsa.gov' },
   { from: 'www.18f.gov', to: '18f.gsa.gov' },
-  { from: 'app.gov', to: 'apps.gov' },
-  { from: 'www.app.gov', to: 'apps.gov' },
   { from: 'jobs.18f.gov', to: 'join.18f.gov' },
   { from: 'join.18f.gov', to: '18f.gsa.gov/join', noPath: true },
   { from: 'digitalgov.gov', to: 'digital.gov', redirectCode: 301 },


### PR DESCRIPTION
All PRs must receive approval from a member of the Federalist team.
