### PR TITLE
Add redirect for modular contracting

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,3 +59,4 @@ services:
       - app:innovation-toolkit-prototype.18f.gov
       - app:guides.18f.gov
       - app:open-source-program.18f.gov
+      - app:modularcontracting.18f.gov

--- a/templates/_federalist-redirects.njk
+++ b/templates/_federalist-redirects.njk
@@ -203,6 +203,14 @@ server {
   return 301 https://$target_domain;
 }
 
+# modularcontracting.18f.gov to https://github.com/18F/Modular-Contracting-And-Agile-Development
+server {
+  listen {{ PORT }};
+  set $target_domain github.com/18F/Modular-Contracting-And-Agile-Development;
+  server_name modularcontracting.18f.gov;
+  return 301 https://$target_domain;
+}
+
 
 # open-source-guide.18f.gov to github.com/18F/open-source-guide
 server {


### PR DESCRIPTION
- in part of the modular contracting sunset - noted in the draft post here: https://federalist-proxy.app.cloud.gov/preview/18f/18f.gsa.gov/modular-contracting/2019/04/09/why-we-love-modular-contracting/,

We will be archiving the site in favor of the repository
