### PR TITLE
redirect C2 to Handbook

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -69,3 +69,5 @@ services:
       - app:agile-bpa.18f.gov
       - app:slides.18f.gov
       - app:fedspendingtransparency.18f.gov
+      - app:cap.18f.gov
+      - app:requests.18f.gov

--- a/templates/_federalist-redirects.njk
+++ b/templates/_federalist-redirects.njk
@@ -338,11 +338,13 @@ server {
 # C2: cap.18f.gov and requests.18f.gov to https://handbook.18f.gov/purchase-requests/
 server {
   listen {{ PORT }};
+  set $target_domain docs.google.com/forms/d/e/1FAIpQLSd-GoOE9xWWfJvdZNRP3SE7mj5ysI_RfM8brxdG8YpyJV9yKA/viewform;
   server_name cap.18f.gov;
-  return 301 https://docs.google.com/forms/d/e/1FAIpQLSd-GoOE9xWWfJvdZNRP3SE7mj5ysI_RfM8brxdG8YpyJV9yKA/viewform;
+  return 301 https://$target_domain
 }
 server {
   listen {{ PORT }};
+  set $target_domain docs.google.com/forms/d/e/1FAIpQLSd-GoOE9xWWfJvdZNRP3SE7mj5ysI_RfM8brxdG8YpyJV9yKA/viewform;
   server_name requests.18f.gov;
-  return 301 https://docs.google.com/forms/d/e/1FAIpQLSd-GoOE9xWWfJvdZNRP3SE7mj5ysI_RfM8brxdG8YpyJV9yKA/viewform;
+  return 301 https://$target_domain
 }

--- a/templates/_federalist-redirects.njk
+++ b/templates/_federalist-redirects.njk
@@ -1,4 +1,3 @@
-
 # Originally from https://github.com/18F/federalist-redirects/blob/b60293b49d01c429092195bc6d446690423dcf3b/nginx.conf
 server {
   listen {{ PORT }};
@@ -334,4 +333,11 @@ server {
   set $target_domain github.com/fedspendingtransparency/fedspendingtransparency.github.io;
   server_name fedspendingtransparency.18f.gov;
   return 301 https://$target_domain;
+}
+
+# C2: cap.18f.gov and requests.18f.gov to https://handbook.18f.gov/purchase-requests/
+server {
+  listen {{ PORT }};
+  server_name cap.18f.gov requests.18f.gov;
+  return 301 https://handbook.18f.gov/purchase-requests/;
 }

--- a/templates/_federalist-redirects.njk
+++ b/templates/_federalist-redirects.njk
@@ -339,10 +339,10 @@ server {
 server {
   listen {{ PORT }};
   server_name cap.18f.gov;
-  return 301 https://handbook.18f.gov/purchase-requests/;
+  return 301 https://docs.google.com/forms/d/e/1FAIpQLSd-GoOE9xWWfJvdZNRP3SE7mj5ysI_RfM8brxdG8YpyJV9yKA/viewform;
 }
 server {
   listen {{ PORT }};
   server_name requests.18f.gov;
-  return 301 https://handbook.18f.gov/purchase-requests/;
+  return 301 https://docs.google.com/forms/d/e/1FAIpQLSd-GoOE9xWWfJvdZNRP3SE7mj5ysI_RfM8brxdG8YpyJV9yKA/viewform;
 }

--- a/templates/_federalist-redirects.njk
+++ b/templates/_federalist-redirects.njk
@@ -340,11 +340,11 @@ server {
   listen {{ PORT }};
   set $target_domain docs.google.com/forms/d/e/1FAIpQLSd-GoOE9xWWfJvdZNRP3SE7mj5ysI_RfM8brxdG8YpyJV9yKA/viewform;
   server_name cap.18f.gov;
-  return 301 https://$target_domain
+  return 301 https://$target_domain;
 }
 server {
   listen {{ PORT }};
   set $target_domain docs.google.com/forms/d/e/1FAIpQLSd-GoOE9xWWfJvdZNRP3SE7mj5ysI_RfM8brxdG8YpyJV9yKA/viewform;
   server_name requests.18f.gov;
-  return 301 https://$target_domain
+  return 301 https://$target_domain;
 }

--- a/templates/_federalist-redirects.njk
+++ b/templates/_federalist-redirects.njk
@@ -338,6 +338,11 @@ server {
 # C2: cap.18f.gov and requests.18f.gov to https://handbook.18f.gov/purchase-requests/
 server {
   listen {{ PORT }};
-  server_name cap.18f.gov requests.18f.gov;
+  server_name cap.18f.gov;
+  return 301 https://handbook.18f.gov/purchase-requests/;
+}
+server {
+  listen {{ PORT }};
+  server_name requests.18f.gov;
   return 301 https://handbook.18f.gov/purchase-requests/;
 }

--- a/templates/manifest-prod.yml.njk
+++ b/templates/manifest-prod.yml.njk
@@ -33,6 +33,8 @@ routes:
 - route: agile-bpa.18f.gov
 - route: slides.18f.gov
 - route: fedspendingtransparency.18f.gov
+- route: cap.18f.gov
+- route: requests.18f.gov
 {% for page in PAGE_CONFIGS -%}
 - route: {{ page.to }}.{{ page.toDomain }}
 {% endfor -%}


### PR DESCRIPTION
Part of https://github.com/18F/tts-micropurchase-bots/issues/30.

Hey hey- What needs to happen beyond this? Presumably a [DNS](https://github.com/18F/dns/blob/master/terraform/18f.gov.tf) change? Are those steps written up anywhere?