### PR TITLE
remove jobs/join.18f.gov - redirect handles in 18f/dns

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,8 +29,6 @@ services:
       - app:www.connect.gov
       - app:18f.gov
       - app:www.18f.gov
-      - app:jobs.18f.gov
-      - app:join.18f.gov
       - app:pages.18f.gov
       - app:digitalgov.gov
       - app:www.digitalgov.gov

--- a/templates/_federalist-redirects.njk
+++ b/templates/_federalist-redirects.njk
@@ -15,20 +15,6 @@ server {
   return 302 https://$target_domain$request_uri;
 }
 
-server {
-  listen {{ PORT }};
-  set $target_domain join.18f.gov;
-  server_name jobs.18f.gov;
-  return 302 https://$target_domain$request_uri;
-}
-
-server {
-  listen {{ PORT }};
-  server_name join.18f.gov;
-  return 302 https://18f.gsa.gov/join/;
-}
-
-
 # api-all-the-x.18f.gov to github.com/18F/API-All-the-X
 server {
   listen {{ PORT }};

--- a/templates/manifest-prod.yml.njk
+++ b/templates/manifest-prod.yml.njk
@@ -8,8 +8,6 @@ applications:
 instances: 4
 routes:
 - route: pages-redirects.app.cloud.gov
-- route: join.18f.gov
-- route: jobs.18f.gov
 - route: pif.gov
 - route: apply.pif.gov
 - route: www.pif.gov

--- a/test/integration/test_federalist_redirects.js
+++ b/test/integration/test_federalist_redirects.js
@@ -15,8 +15,6 @@ const expectedRedirects = [
   { from: 'apply.pif.gov', to: 'presidentialinnovationfellows.gov/apply', noPath: true },
   { from: '18f.gov', to: '18f.gsa.gov' },
   { from: 'www.18f.gov', to: '18f.gsa.gov' },
-  { from: 'jobs.18f.gov', to: 'join.18f.gov' },
-  { from: 'join.18f.gov', to: '18f.gsa.gov/join', noPath: true },
   { from: 'digitalgov.gov', to: 'digital.gov', redirectCode: 301 },
   { from: 'www.digitalgov.gov', to: 'digital.gov', redirectCode: 301 },
   { from: 'demo.digitalgov.gov', to: 'demo.digital.gov', redirectCode: 301 },


### PR DESCRIPTION
All PRs must receive approval from a member of the Federalist team.
