### PR TITLE
remove hsts for usability.gov

### DIFF
--- a/templates/_federalist-redirects.njk
+++ b/templates/_federalist-redirects.njk
@@ -65,12 +65,11 @@ server {
   return 301 https://$target_domain$request_uri;
 }
 
-# digitalgov.gov to digital.gov
+# usability.gov to usability.gov
 server {
   listen {{ PORT }};
   set $target_domain www.usability.gov;
   server_name usability.gov;
-  add_header Strict-Transport-Security 'max-age=63072000; includeSubDomains; preload';
   return 301 https://$target_domain$request_uri;
 }
 


### PR DESCRIPTION
All PRs must receive approval from a member of the Federalist team.
