### PR TITLE
remove non-existent federalist templates domains

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -61,7 +61,6 @@ services:
       - app:modularcontracting.18f.gov
       - app:v2.designsystem.digital.gov
       - app:micropurchase.18f.gov
-      - app:federalist-modern-team-template.18f.gov
       - app:acqstack-journeymap.18f.gov
       - app:boise.18f.gov
       - app:paid-leave-prototype.18f.gov
@@ -75,7 +74,6 @@ services:
       - app:handbook.18f.gov
       - app:frontend.18f.gov
       - app:proposal.pif.gov
-      - app:federalist-report-template.18f.gov
       - app:www.search.gov
       - app:ads.18f.gov
       - app:usability.gov

--- a/templates/_federalist-redirects.njk
+++ b/templates/_federalist-redirects.njk
@@ -289,15 +289,6 @@ server {
   return 301 https://$target_domain;
 }
 
-
-# federalist-modern-team-template.18f.gov to github.com/18F/federalist-modern-team-template
-server {
-  listen {{ PORT }};
-  set $target_domain github.com/18F/federalist-modern-team-template;
-  server_name federalist-modern-team-template.18f.gov;
-  return 301 https://$target_domain;
-}
-
 # boise.18f.gov to github.com/18f/boise
 server {
   listen {{ PORT }};
@@ -389,14 +380,6 @@ server {
   listen {{ PORT }};
   set $target_domain docs.google.com/forms/d/e/1FAIpQLSeIVylFhpyyv9cBQFKnXa6x3sJsZN4HkkqhNcYgHfSHjv-5kw/viewform;
   server_name proposal.pif.gov;
-  return 301 https://$target_domain;
-}
-
-# federalist-report-template.18f.gov to github repo
-server {
-  listen {{ PORT }};
-  set $target_domain github.com/18f/federalist-report-template;
-  server_name federalist-report-template.18f.gov;
   return 301 https://$target_domain;
 }
 

--- a/templates/manifest-prod.yml.njk
+++ b/templates/manifest-prod.yml.njk
@@ -26,7 +26,6 @@ routes:
 - route: blogging-guide.18f.gov
 - route: v2.designsystem.digital.gov
 - route: micropurchase.18f.gov
-- route: federalist-modern-team-template.18f.gov
 - route: acqstack-journeymap.18f.gov
 - route: boise.18f.gov
 - route: agile-bpa.18f.gov
@@ -39,7 +38,6 @@ routes:
 - route: handbook.18f.gov
 - route: frontend.18f.gov
 - route: proposal.pif.gov
-- route: federalist-report-template.18f.gov
 - route: www.search.gov
 - route: ads.18f.gov
 - route: paid-leave-prototype.18f.gov


### PR DESCRIPTION
these domains no longer have DNS entries

All PRs must receive approval from a member of the Federalist team.
