### PR TITLE
remove connect.gov

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,8 +25,6 @@ services:
       - app:pif.gov
       - app:apply.pif.gov
       - app:www.pif.gov
-      - app:connect.gov
-      - app:www.connect.gov
       - app:18f.gov
       - app:www.18f.gov
       - app:pages.18f.gov

--- a/templates/manifest-prod.yml.njk
+++ b/templates/manifest-prod.yml.njk
@@ -11,8 +11,6 @@ routes:
 - route: pif.gov
 - route: apply.pif.gov
 - route: www.pif.gov
-- route: connect.gov
-- route: www.connect.gov
 - route: pages.18f.gov
 - route: 18f.gov
 - route: www.18f.gov


### PR DESCRIPTION
cleanup -- connect.gov is no longer owned by TTS

All PRs must receive approval from a member of the Federalist team.
