### PR TITLE
Update config to redirect govconnect.18f.gov to github repo

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -79,3 +79,4 @@ services:
       - app:developer.login.gov
       - app:components.designsystem.digital.gov
       - app:climate-data-user-study.18f.gov
+      - app:govconnect.18f.gov

--- a/templates/_federalist-redirects.njk
+++ b/templates/_federalist-redirects.njk
@@ -437,3 +437,11 @@ server {
   server_name climate-data-user-study.18f.gov;
   return 301 https://$target_domain;
 }
+
+# govconnect.18f.gov to github.com/18F/govconnect
+server {
+  listen {{ PORT }};
+  set $target_domain github.com/18F/govconnect;
+  server_name govconnect.18f.gov;
+  return 301 https://$target_domain;
+}

--- a/templates/manifest-prod.yml.njk
+++ b/templates/manifest-prod.yml.njk
@@ -44,6 +44,7 @@ routes:
 - route: developer.login.gov
 - route: components.designsystem.digital.gov
 - route: climate-data-user-study.18f.gov
+- route: govconnect.18f.gov
 {% for page in PAGE_CONFIGS -%}
 - route: {{ page.to }}.{{ page.toDomain }}
 {% endfor -%}


### PR DESCRIPTION
Decommissioning govconnect.18f.gov based on https://github.com/18F/tts-tech-portfolio/issues/1027
