### PR TITLE
Redirect status.login.gov

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -80,3 +80,4 @@ services:
       - app:components.designsystem.digital.gov
       - app:climate-data-user-study.18f.gov
       - app:govconnect.18f.gov
+      - app:status.login.gov

--- a/pages.yml
+++ b/pages.yml
@@ -60,5 +60,8 @@
 - slides
 - from: state-faq
   to: modularcontracting
+- from: status.login.gov
+  toDomain: logingov.statuspage.io
+  to: www # technically not true but it's a required field
 - testing-cookbook
 - writing-lab-guide

--- a/templates/_federalist-redirects.njk
+++ b/templates/_federalist-redirects.njk
@@ -445,3 +445,11 @@ server {
   server_name govconnect.18f.gov;
   return 301 https://$target_domain;
 }
+
+# status.login.gov to logingov.statuspage.io
+server {
+  listen {{ PORT }};
+  set $target_domain logingov.statuspage.io;
+  server_name status.login.gov;
+  return 301 https://$target_domain;
+}

--- a/templates/manifest-prod.yml.njk
+++ b/templates/manifest-prod.yml.njk
@@ -45,6 +45,7 @@ routes:
 - route: components.designsystem.digital.gov
 - route: climate-data-user-study.18f.gov
 - route: govconnect.18f.gov
+- route: status.login.gov
 {% for page in PAGE_CONFIGS -%}
 - route: {{ page.to }}.{{ page.toDomain }}
 {% endfor -%}


### PR DESCRIPTION
Redo of #187 now that we have the right DNS stuff in place already

This reverts commit fcf89b5a41be308f19475e059ef18bc510726fe6, reversing
changes made to a2a13cb7d69ac691b89467e019899f34351330e6.

All PRs must receive approval from a member of the Federalist team.
