### PR TITLE
Remove redirect for atf-eregs for now

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -71,7 +71,7 @@ services:
       - app:www.findtreatment.gov
       - app:federalist-docs.18f.gov
       - app:private-eye.18f.gov
-      - app:atf-eregs.18f.gov
+      # - app:atf-eregs.18f.gov
       - app:agile-labor-categories.18f.gov
       - app:handbook.18f.gov
       - app:frontend.18f.gov

--- a/templates/_federalist-redirects.njk
+++ b/templates/_federalist-redirects.njk
@@ -375,12 +375,12 @@ server {
 }
 
 # atf-eregs.18f.gov to regulations.atf.gov
-server {
+{# server {
   listen {{ PORT }};
   set $target_domain regulations.atf.gov;
   server_name atf-eregs.18f.gov;
   return 301 https://$target_domain;
-}
+} #}
 
 # agile-labor-categories.18f.gov to derisking-guide.18f.gov
 server {

--- a/templates/manifest-prod.yml.njk
+++ b/templates/manifest-prod.yml.njk
@@ -34,7 +34,7 @@ routes:
 - route: c2.18f.gov
 - route: www.findtreatment.gov
 - route: federalist-docs.18f.gov
-- route: atf-eregs.18f.gov
+{# - route: atf-eregs.18f.gov #}
 - route: private-eye.18f.gov
 - route: agile-labor-categories.18f.gov
 - route: handbook.18f.gov


### PR DESCRIPTION
Cannot create the redirect until the existing one is removed from the atf eregs cloud.gov org.
