### PR TITLE
Add redirects for paygap.pif.gov and tophealth.pif.gov

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,6 +25,8 @@ services:
       - app:pif.gov
       - app:apply.pif.gov
       - app:www.pif.gov
+      - app:paygap.pif.gov
+      - app:tophealth.pif.gov      
       - app:18f.gov
       - app:www.18f.gov
       - app:pages.18f.gov

--- a/templates/_federalist-redirects.njk
+++ b/templates/_federalist-redirects.njk
@@ -281,6 +281,22 @@ server {
   return 302 https://$target_domain;
 }
 
+# paygap.pif.gov to pif.gov
+server {
+  listen {{ PORT }};
+  set $target_domain pif.gov;
+  server_name paygap.pif.gov;
+  return 301 https://$target_domain;
+}
+
+# tophealth.pif.gov to pif.gov
+server {
+  listen {{ PORT }};
+  set $target_domain pif.gov;
+  server_name tophealth.pif.gov;
+  return 301 https://$target_domain;
+}
+
 # micropurchase.18f.gov to github.com/18f/micropurchase-archive
 server {
   listen {{ PORT }};

--- a/templates/manifest-prod.yml.njk
+++ b/templates/manifest-prod.yml.njk
@@ -11,6 +11,8 @@ routes:
 - route: pif.gov
 - route: apply.pif.gov
 - route: www.pif.gov
+- route: paygap.pif.gov
+- route: tophealth.pif.gov
 - route: pages.18f.gov
 - route: 18f.gov
 - route: www.18f.gov


### PR DESCRIPTION
Redirect paygap.pif.gov and tophealth.pif.gov to pif.gov