### PR TITLE
Add include subdomains preload to www.search.gov

### DIFF
--- a/templates/_federalist-redirects.njk
+++ b/templates/_federalist-redirects.njk
@@ -3,7 +3,7 @@ server {
   listen {{ PORT }};
   set $target_domain presidentialinnovationfellows.gov;
   server_name pif.gov www.pif.gov;
-  add_header Strict-Transport-Security 'max-age=31536000; includeSubDomains; preload';  
+  add_header Strict-Transport-Security 'max-age=31536000; includeSubDomains; preload';
   return 302 https://$target_domain$request_uri;
 }
 
@@ -436,6 +436,7 @@ server {
   listen {{ PORT }};
   set $target_domain search.gov;
   server_name www.search.gov;
+  add_header Strict-Transport-Security 'max-age=31536000; includeSubDomains; preload';
   return 301 https://$target_domain$request_uri;
 }
 


### PR DESCRIPTION
All PRs must receive approval from a member of the Federalist team.
- Add Strict-Transport-Security 'max-age=31536000; includeSubDomains; preload' to www.search.gov