### PR TITLE
Redirect portfolios.18f.gov to 18f.gsa.gov.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -85,3 +85,4 @@ services:
       - app:components.designsystem.digital.gov
       - app:climate-data-user-study.18f.gov
       - app:govconnect.18f.gov
+      - app:portfolios.18f.gov

--- a/templates/_federalist-redirects.njk
+++ b/templates/_federalist-redirects.njk
@@ -487,3 +487,11 @@ server {
   server_name govconnect.18f.gov;
   return 301 https://$target_domain;
 }
+
+# portfolios.18f.gov to 18f.gsa.gov
+server {
+  listen {{ PORT }};
+  set $target_domain 18f.gsa.gov;
+  server_name portfolios.18f.gov;
+  return 301 https://$target_domain;
+}

--- a/templates/manifest-prod.yml.njk
+++ b/templates/manifest-prod.yml.njk
@@ -50,6 +50,7 @@ routes:
 - route: components.designsystem.digital.gov
 - route: climate-data-user-study.18f.gov
 - route: govconnect.18f.gov
+- route: portfolios.18f.gov
 {% for page in PAGE_CONFIGS -%}
 - route: {{ page.to }}.{{ page.toDomain }}
 {% endfor -%}


### PR DESCRIPTION
Related: https://github.com/18F/dns/issues/599

All PRs must receive approval from a member of the Federalist team.
