### PR TITLE
Add partners.login.gov redirect configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ server {
   return 301 https://$target_domain;
 }
 ```
-3. Add yourdOrigDomain.gov as an external link to [`docker-compose.yml`](/docker-compose.yml)
+3. Add yourOrigDomain.gov as an external link to [`docker-compose.yml`](/docker-compose.yml)
 ```
 app:yourOrigDomain.gov
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -82,6 +82,7 @@ services:
       - app:ads.18f.gov
       - app:usability.gov
       - app:developer.login.gov
+      - app:partners.login.gov
       - app:components.designsystem.digital.gov
       - app:climate-data-user-study.18f.gov
       - app:govconnect.18f.gov

--- a/templates/_federalist-redirects.njk
+++ b/templates/_federalist-redirects.njk
@@ -514,15 +514,15 @@ server {
     return 301 https://www.login.gov/partners/;
   }
 
-  location ~ /product/? {
+  location ~ ^/product/?$ {
     return 301 https://www.login.gov/partners/our-services/;
   }
 
-  location ~ /sandbox/? {
+  location ~ ^/sandbox/?$ {
     return 301 https://developers.login.gov/;
   }
 
-  location ~ /state-and-local/? {
+  location ~ ^/state-and-local/?$ {
     return 301 https://www.login.gov/partners/state-and-local/;
   }
 }

--- a/templates/_federalist-redirects.njk
+++ b/templates/_federalist-redirects.njk
@@ -505,17 +505,17 @@ server {
   return 301 https://$target_domain$request_uri;
 }
 
-# partners.login.gov to login.gov/partners
+# partners.login.gov to www.login.gov/partners
 server {
   listen {{ PORT }};
   server_name partners.login.gov;
 
   location = / {
-    return 301 https://login.gov/partners/;
+    return 301 https://www.login.gov/partners/;
   }
 
   location ~ /product/? {
-    return 301 https://login.gov/partners/our-services/;
+    return 301 https://www.login.gov/partners/our-services/;
   }
 
   location ~ /sandbox/? {
@@ -523,6 +523,6 @@ server {
   }
 
   location ~ /state-and-local/? {
-    return 301 https://login.gov/partners/state-and-local/;
+    return 301 https://www.login.gov/partners/state-and-local/;
   }
 }

--- a/templates/_federalist-redirects.njk
+++ b/templates/_federalist-redirects.njk
@@ -504,3 +504,25 @@ server {
   add_header Strict-Transport-Security 'max-age=31536000; preload';
   return 301 https://$target_domain$request_uri;
 }
+
+# partners.login.gov to login.gov/partners
+server {
+  listen {{ PORT }};
+  server_name partners.login.gov;
+
+  location = / {
+    return 301 https://login.gov/partners/;
+  }
+
+  location ~ /product/? {
+    return 301 https://login.gov/partners/our-services/;
+  }
+
+  location ~ /sandbox/? {
+    return 301 https://developers.login.gov/;
+  }
+
+  location ~ /state-and-local/? {
+    return 301 https://login.gov/partners/state-and-local/;
+  }
+}

--- a/templates/manifest-prod.yml.njk
+++ b/templates/manifest-prod.yml.njk
@@ -47,6 +47,7 @@ routes:
 - route: paid-leave-prototype.18f.gov
 - route: usability.gov
 - route: developer.login.gov
+- route: partners.login.gov
 - route: components.designsystem.digital.gov
 - route: climate-data-user-study.18f.gov
 - route: govconnect.18f.gov

--- a/test/integration/test_federalist_redirects.js
+++ b/test/integration/test_federalist_redirects.js
@@ -30,6 +30,13 @@ const expectedRedirects = [
   { from: 'usability.gov', to: 'www.usability.gov', redirectCode: 301 },
   { from: 'emerging.digital.gov', to: 'digital.gov/topics/emerging-tech', redirectCode: 301, noPath: true },
   { from: 'components.designsystem.digital.gov', to: 'designsystem.digital.gov/components', redirectCode: 301, noPath: true },
+  { from: 'partners.login.gov', to: 'www.login.gov/partners/', redirectCode: 301, noPath: true },
+  { from: 'partners.login.gov/product/', to: 'www.login.gov/partners/our-services/', redirectCode: 301, noPath: true },
+  { from: 'partners.login.gov/product', to: 'www.login.gov/partners/our-services/', redirectCode: 301, noPath: true },
+  { from: 'partners.login.gov/sandbox/', to: 'developers.login.gov', redirectCode: 301, noPath: true },
+  { from: 'partners.login.gov/sandbox', to: 'developers.login.gov', redirectCode: 301, noPath: true },
+  { from: 'partners.login.gov/state-and-local/', to: 'www.login.gov/partners/state-and-local/', redirectCode: 301, noPath: true },
+  { from: 'partners.login.gov/state-and-local', to: 'www.login.gov/partners/state-and-local/', redirectCode: 301, noPath: true },
 ];
 
 function redirectOk(t, from, to, redirectCode) {

--- a/test/integration/test_federalist_redirects.js
+++ b/test/integration/test_federalist_redirects.js
@@ -30,13 +30,13 @@ const expectedRedirects = [
   { from: 'usability.gov', to: 'www.usability.gov', redirectCode: 301 },
   { from: 'emerging.digital.gov', to: 'digital.gov/topics/emerging-tech', redirectCode: 301, noPath: true },
   { from: 'components.designsystem.digital.gov', to: 'designsystem.digital.gov/components', redirectCode: 301, noPath: true },
-  { from: 'partners.login.gov', to: 'www.login.gov/partners/', redirectCode: 301, noPath: true },
-  { from: 'partners.login.gov/product/', to: 'www.login.gov/partners/our-services/', redirectCode: 301, noPath: true },
-  { from: 'partners.login.gov/product', to: 'www.login.gov/partners/our-services/', redirectCode: 301, noPath: true },
+  { from: 'partners.login.gov', to: 'www.login.gov/partners', redirectCode: 301, noPath: true },
+  { from: 'partners.login.gov/product/', to: 'www.login.gov/partners/our-services', redirectCode: 301, noPath: true },
+  { from: 'partners.login.gov/product', to: 'www.login.gov/partners/our-services', redirectCode: 301, noPath: true },
   { from: 'partners.login.gov/sandbox/', to: 'developers.login.gov', redirectCode: 301, noPath: true },
   { from: 'partners.login.gov/sandbox', to: 'developers.login.gov', redirectCode: 301, noPath: true },
-  { from: 'partners.login.gov/state-and-local/', to: 'www.login.gov/partners/state-and-local/', redirectCode: 301, noPath: true },
-  { from: 'partners.login.gov/state-and-local', to: 'www.login.gov/partners/state-and-local/', redirectCode: 301, noPath: true },
+  { from: 'partners.login.gov/state-and-local/', to: 'www.login.gov/partners/state-and-local', redirectCode: 301, noPath: true },
+  { from: 'partners.login.gov/state-and-local', to: 'www.login.gov/partners/state-and-local', redirectCode: 301, noPath: true },
 ];
 
 function redirectOk(t, from, to, redirectCode) {


### PR DESCRIPTION
The site https://partners.login.gov is hosted on Federalist, but now redirects to its new location at https://login.gov/partners . This is currently implemented using static site redirects through HTML markup (`<meta http-equiv="refresh">` via [`jekyll-redirect-from`](https://rubygems.org/gems/jekyll-redirect-from), [see example page source](https://github.com/18F/identity-partners-site/blob/main/_pages/index.md)).

The changes proposed here would create proper 301 redirects for the domain and a set of paths, allowing us to decommission the site in the Federalist dashboard. 

* https://partners.login.gov/ :arrow_right: https://login.gov/partners/
* https://partners.login.gov/product/ :arrow_right: https://login.gov/partners/our-services/
* https://partners.login.gov/sandbox/ :arrow_right: https://developers.login.gov/
* https://partners.login.gov/state-and-local/ :arrow_right: https://login.gov/partners/state-and-local/

TTS Slack discussion for context: https://gsa-tts.slack.com/archives/C16RSBG49/p1664973357958659