### PR TITLE
Redirect www.usability.gov to www.digital.gov/topics/usability

### DIFF
--- a/pages.yml
+++ b/pages.yml
@@ -57,4 +57,8 @@
 - from: state-faq
   to: modularcontracting
 - testing-cookbook
+- from: usability
+  to: digital
+  toDomain: digital.gov
+  toPath: /topics/usability
 - writing-lab-guide

--- a/templates/_federalist-redirects.njk
+++ b/templates/_federalist-redirects.njk
@@ -75,6 +75,15 @@ server {
   return 301 https://$target_domain$request_uri;
 }
 
+# usability.gov to www.digital.gov/topics/usability/
+server {
+  listen {{ PORT }};
+  set $target_domain www.digital.gov/topics/usability/
+  server_name usability.gov;
+  add_header Strict-Transport-Security 'max-age=31536000; includeSubDomains; preload';
+  return 301 https://$target_domain;
+}
+
 # summit.digitalgov.gov to digital.gov
 server {
   listen {{ PORT }};


### PR DESCRIPTION
## Changes proposed in this pull request:

- Redirect www.usability.gov to www.digital.gov/topics/usability

## Security considerations

[Note the any security considerations here, or make note of why there are none]
