### PR TITLE
feat: Add methods.18f.gov redirect to guides.18f.gov/methods

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -96,3 +96,4 @@ services:
       - app:eng-hiring.18f.gov
       - app:engineering.18f.gov
       - app:product-guide.18f.gov
+      - app:methods.18f.gov

--- a/templates/_federalist-redirects.njk
+++ b/templates/_federalist-redirects.njk
@@ -388,7 +388,7 @@ server {
   set $target_domain regulations.atf.gov;
   server_name atf-eregs.18f.gov;
   return 301 https://$target_domain;
-} 
+}
 
 # agile-labor-categories.18f.gov to derisking-guide.18f.gov
 server {
@@ -621,5 +621,15 @@ server {
 
   location / {
     return 301 https://guides.18f.gov/ux-guide$uri;
+  }
+}
+
+# methods.18f.gov to guides.18f.gov/methods/
+server {
+  listen {{ PORT }};
+  server_name methods.18f.gov;
+
+  location / {
+    return 301 https://guides.18f.gov/methods$uri;
   }
 }


### PR DESCRIPTION
## Changes proposed in this pull request:

- Adds methods.18f.gov redirect to guides.18f.gov/methods
- Related to #238 

## Security considerations

None
