### PR TITLE
redirect demo.pra.digital.gov to pra.digital.gov

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,6 +32,8 @@ services:
       - app:www.digitalgov.gov
       - app:emerging.digital.gov
       - app:summit.digitalgov.gov
+      - app:pra.digital.gov
+      - app:demo.pra.digital.gov
       - app:www.digital.gov
       - app:openopps.digitalgov.gov
       - app:plainlanguage.gov

--- a/pages.yml
+++ b/pages.yml
@@ -58,3 +58,5 @@
   to: modularcontracting
 - testing-cookbook
 - writing-lab-guide
+- from: demo.pra.digital.gov
+  to: pra.digital.gov

--- a/templates/_federalist-redirects.njk
+++ b/templates/_federalist-redirects.njk
@@ -696,3 +696,9 @@ server {
   }
 
 }
+server {
+  listen {{ PORT }};
+  set $target_domain pra.digital.gov;
+  server_name demo.pra.digital.gov;
+  return 301 https://$target_domain$request_uri;
+}

--- a/templates/manifest-prod.yml.njk
+++ b/templates/manifest-prod.yml.njk
@@ -19,6 +19,7 @@ routes:
 - route: digitalgov.gov
 - route: www.digitalgov.gov
 - route: accessibility.digital.gov
+- route: pra.digital.gov
 - route: emerging.digital.gov
 - route: summit.digitalgov.gov
 - route: www.digital.gov

--- a/test/integration/test_federalist_redirects.js
+++ b/test/integration/test_federalist_redirects.js
@@ -46,6 +46,7 @@ const expectedRedirects = [
   { from: 'join.tts.gsa.gov', to: 'tts.gsa.gov/join', redirectCode: 301 },
   { from: 'join.tts.gsa.gov/working-at-tts/', to: 'handbook.tts.gsa.gov/about-us/tts-history', redirectCode: 301, noPath: true },
   { from: 'join.tts.gsa.gov/tts-offices/', to: 'handbook.tts.gsa.gov/#tts-offices', redirectCode: 301, noPath: true },
+  { from: 'demo.pra.digital.gov', to: 'pra.digital.gov', redirectCode: 301, noPath: true },
 ];
 
 function redirectOk(t, from, to, redirectCode) {


### PR DESCRIPTION
## Changes proposed in this pull request:

- redirect demo.pra.digital.gov to pra.digital.gov

<details>

<summary>Logs from passing test are below</summary>

rileydseaburg@FCOH2J-R2V9HWD2 pages-redirects % npm run build-docker && npm run test-docker

> pages-redirects@1.0.0 build-docker
> npm run build && docker compose build


> pages-redirects@1.0.0 build
> node build.js

Wrote nginx configs and manifest-prod.yml to ./out
WARN[0000] /Users/rileydseaburg/Documents/pages-redirects/docker-compose.yml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion 
[+] Building 1.1s (20/20) FINISHED                                                 docker:desktop-linux
 => [app internal] load build definition from Dockerfile-app                                       0.0s
 => => transferring dockerfile: 151B                                                               0.0s
 => [app internal] load metadata for docker.io/library/nginx:1.11-alpine                           0.4s
 => [app internal] load .dockerignore                                                              0.0s
 => => transferring context: 95B                                                                   0.0s
 => [app internal] load build context                                                              0.0s
 => => transferring context: 23.31kB                                                               0.0s
 => [app 1/2] FROM docker.io/library/nginx:1.11-alpine@sha256:5aadb68304a38a8e2719605e4e180413f39  0.0s
 => CACHED [app 2/2] COPY out/nginx.docker.conf /etc/nginx/nginx.conf                              0.0s
 => [app] exporting to image                                                                       0.0s
 => => exporting layers                                                                            0.0s
 => => writing image sha256:093c6ed8f2e6898a4d4582da828ba7955b48be2e6ebeebe130e3a71c2e22a24d       0.0s
 => => naming to docker.io/library/pages-redirects-app                                             0.0s
 => [app] resolving provenance for metadata file                                                   0.0s
 => [test_client internal] load build definition from Dockerfile-test_client                       0.0s
 => => transferring dockerfile: 208B                                                               0.0s
 => [test_client internal] load metadata for docker.io/library/node:20-bullseye-slim               0.4s
 => [test_client internal] load .dockerignore                                                      0.0s
 => => transferring context: 95B                                                                   0.0s
 => [test_client 1/6] FROM docker.io/library/node:20-bullseye-slim@sha256:c121fcd9656dde8ca373d1a  0.0s
 => [test_client internal] load build context                                                      0.0s
 => => transferring context: 215.36kB                                                              0.0s
 => CACHED [test_client 2/6] WORKDIR /src                                                          0.0s
 => CACHED [test_client 3/6] COPY package.json /src                                                0.0s
 => CACHED [test_client 4/6] COPY package-lock.json /src                                           0.0s
 => CACHED [test_client 5/6] RUN npm install                                                       0.0s
 => [test_client 6/6] ADD . /src                                                                   0.0s
 => [test_client] exporting to image                                                               0.0s
 => => exporting layers                                                                            0.0s
 => => writing image sha256:0fab861332f7fff224cc1d7dd2570e0b5bb3edbbb70df129ca01666179dbdec9       0.0s
 => => naming to docker.io/library/pages-redirects-test_client                                     0.0s
 => [test_client] resolving provenance for metadata file                                           0.0s

> pages-redirects@1.0.0 test-docker
> docker compose up -d && sleep 2 && docker compose run test_client npm run test-integration && docker compose stop

WARN[0000] /Users/rileydseaburg/Documents/pages-redirects/docker-compose.yml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion 
WARN[0000] Found orphan containers ([pages-redirects-test_client-run-9dfa25b92d09 pages-redirects-test_client-run-70e91b3e5b82 pages-redirects-test_client-run-d4ec203629ca pages-redirects-test_client-run-3bc45fd6e7c4 pages-redirects-test_client-run-eb8ae9102777 pages-redirects-test_client-run-196fda3dcc99 pages-redirects-test_client-run-b635fc5f1693]) for this project. If you removed or renamed this service in your compose file, you can run this command with the --remove-orphans flag to clean it up. 
[+] Running 2/2
 ✔ Container pages-redirects-app-1          Running                                                0.0s 
 ✔ Container pages-redirects-test_client-1  Started                                                0.1s 
WARN[0000] /Users/rileydseaburg/Documents/pages-redirects/docker-compose.yml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion 
WARN[0000] Found orphan containers ([pages-redirects-test_client-run-9dfa25b92d09 pages-redirects-test_client-run-70e91b3e5b82 pages-redirects-test_client-run-d4ec203629ca pages-redirects-test_client-run-3bc45fd6e7c4 pages-redirects-test_client-run-eb8ae9102777 pages-redirects-test_client-run-196fda3dcc99 pages-redirects-test_client-run-b635fc5f1693]) for this project. If you removed or renamed this service in your compose file, you can run this command with the --remove-orphans flag to clean it up. 
[+] Creating 1/0
 ✔ Container pages-redirects-app-1  Running                                                        0.0s 

> pages-redirects@1.0.0 test-integration
> tape test/integration/**/*.js | tap-summary --no-progress


# Tests

✔ getServerNames works [pass: 1, fail: 0, duration: 1ms]
✔ nginx.conf and nginx.docker.conf have same server_names [pass: 2, fail: 0, duration: 0ms]
✔ docker-compose.yml has all server_names from nginx.conf [pass: 82, fail: 0, duration: 2ms]
✔ docker-compose.yml has all server_names from nginx.docker.conf [pass: 82, fail: 0, duration: 2ms]
✔ redirects pif.gov to presidentialinnovationfellows.gov (302) [pass: 4, fail: 0, duration: 14ms]
✔ redirects pif.gov/boop to presidentialinnovationfellows.gov/boop (302) [pass: 4, fail: 0, duration: 1ms]
✔ redirects www.pif.gov to presidentialinnovationfellows.gov (302) [pass: 4, fail: 0, duration: 1ms]
✔ redirects www.pif.gov/boop to presidentialinnovationfellows.gov/boop (302) [pass: 4, fail: 0, duration: 1ms]
✔ redirects apply.pif.gov to presidentialinnovationfellows.gov/apply (302) [pass: 16, fail: 0, duration: 3ms]
✔ redirects www.18f.gov to 18f.gsa.gov (302) [pass: 4, fail: 0, duration: 2ms]
✔ redirects www.18f.gov/boop to 18f.gsa.gov/boop (302) [pass: 4, fail: 0, duration: 1ms]
✔ redirects www.18f.gov/chat to docs.google.com/forms/d/e/1FAIpQLSfFoLTRV00g1iIEZv404wJ0BRwNc6CPKbyXMCeXLjDKDv9g4Q/viewform?usp=sf_link (302) [pass: 4, fail: 0, duration: 1ms]
✔ redirects digitalgov.gov to digital.gov (301) [pass: 4, fail: 0, duration: 0ms]
✔ redirects digitalgov.gov/boop to digital.gov/boop (301) [pass: 4, fail: 0, duration: 0ms]
✔ redirects www.digitalgov.gov to digital.gov (301) [pass: 4, fail: 0, duration: 1ms]
✔ redirects www.digitalgov.gov/boop to digital.gov/boop (301) [pass: 4, fail: 0, duration: 1ms]
✔ redirects www.digital.gov to digital.gov (301) [pass: 4, fail: 0, duration: 2ms]
✔ redirects www.digital.gov/boop to digital.gov/boop (301) [pass: 4, fail: 0, duration: 0ms]
✔ redirects summit.digitalgov.gov to digital.gov (302) [pass: 4, fail: 0, duration: 1ms]
✔ redirects summit.digitalgov.gov/boop to digital.gov/boop (302) [pass: 4, fail: 0, duration: 0ms]
✔ redirects plainlanguage.gov to www.plainlanguage.gov (301) [pass: 4, fail: 0, duration: 1ms]
✔ redirects plainlanguage.gov/boop to www.plainlanguage.gov/boop (301) [pass: 4, fail: 0, duration: 0ms]
✔ redirects openopps.digitalgov.gov to openopps.usajobs.gov (301) [pass: 4, fail: 0, duration: 1ms]
✔ redirects openopps.digitalgov.gov/boop to openopps.usajobs.gov/boop (301) [pass: 4, fail: 0, duration: 1ms]
✔ redirects blogging-guide.18f.gov to handbook.18f.gov/blogging (301) [pass: 4, fail: 0, duration: 1ms]
✔ redirects v2.designsystem.digital.gov to designsystem.digital.gov (301) [pass: 4, fail: 0, duration: 1ms]
✔ redirects v2.designsystem.digital.gov/boop to designsystem.digital.gov/boop (301) [pass: 4, fail: 0, duration: 1ms]
✔ redirects www.findtreatment.gov to findtreatment.gov (301) [pass: 4, fail: 0, duration: 1ms]
✔ redirects www.findtreatment.gov/boop to findtreatment.gov/boop (301) [pass: 4, fail: 0, duration: 1ms]
✔ redirects handbook.18f.gov to handbook.tts.gsa.gov (301) [pass: 4, fail: 0, duration: 1ms]
✔ redirects handbook.18f.gov/boop to handbook.tts.gsa.gov/boop (301) [pass: 4, fail: 0, duration: 1ms]
✔ redirects frontend.18f.gov to engineering.18f.gov/frontend (301) [pass: 4, fail: 0, duration: 1ms]
✔ redirects www.search.gov to search.gov (301) [pass: 4, fail: 0, duration: 1ms]
✔ redirects www.search.gov/boop to search.gov/boop (301) [pass: 4, fail: 0, duration: 1ms]
✔ redirects usability.gov to digital.gov/topics/usability (301) [pass: 4, fail: 0, duration: 1ms]
✔ redirects www.usability.gov to digital.gov/topics/usability (301) [pass: 4, fail: 0, duration: 1ms]
✔ redirects accessibility.digital.gov to digital.gov/guides/accessibility-for-teams (302) [pass: 4, fail: 0, duration: 1ms]
✔ redirects emerging.digital.gov to digital.gov/topics/emerging-tech (301) [pass: 4, fail: 0, duration: 1ms]
✔ redirects components.designsystem.digital.gov to designsystem.digital.gov/components (301) [pass: 4, fail: 0, duration: 1ms]
✔ redirects partners.login.gov to www.login.gov/partners (301) [pass: 4, fail: 0, duration: 1ms]
✔ redirects partners.login.gov/product/ to www.login.gov/partners/our-services (301) [pass: 4, fail: 0, duration: 1ms]
✔ redirects partners.login.gov/product to www.login.gov/partners/our-services (301) [pass: 4, fail: 0, duration: 0ms]
✔ redirects partners.login.gov/sandbox/ to developers.login.gov (301) [pass: 4, fail: 0, duration: 1ms]
✔ redirects partners.login.gov/sandbox to developers.login.gov (301) [pass: 4, fail: 0, duration: 1ms]
✔ redirects partners.login.gov/state-and-local/ to www.login.gov/partners/state-and-local (301) [pass: 4, fail: 0, duration: 0ms]
✔ redirects partners.login.gov/state-and-local to www.login.gov/partners/state-and-local (301) [pass: 4, fail: 0, duration: 1ms]
✔ redirects design.login.gov to www.login.gov (301) [pass: 4, fail: 0, duration: 1ms]
✔ redirects usdigitalregistry.digitalgov.gov to touchpoints.app.cloud.gov/registry (301) [pass: 4, fail: 0, duration: 1ms]
✔ redirects join.tts.gsa.gov to tts.gsa.gov/join (301) [pass: 4, fail: 0, duration: 1ms]
✔ redirects join.tts.gsa.gov/boop to tts.gsa.gov/join/boop (301) [pass: 4, fail: 0, duration: 1ms]
✔ redirects join.tts.gsa.gov/working-at-tts/ to handbook.tts.gsa.gov/about-us/tts-history (301) [pass: 4, fail: 0, duration: 1ms]
✔ redirects join.tts.gsa.gov/tts-offices/ to handbook.tts.gsa.gov/#tts-offices (301) [pass: 4, fail: 0, duration: 0ms]
✔ redirects demo.pra.digital.gov to pra.digital.gov (301) [pass: 4, fail: 0, duration: 2ms]
✔ redirect "pages/18franklin" to "18franklin.18f.gov" works [pass: 3, fail: 0, duration: 1ms]
✔ redirect "pages/18franklin/subpath" to "18franklin.18f.gov/subpath" works [pass: 3, fail: 0, duration: 0ms]
✔ redirect "pages/accessibility" to "accessibility.18f.gov" works [pass: 3, fail: 0, duration: 1ms]
✔ redirect "pages/accessibility/subpath" to "accessibility.18f.gov/subpath" works [pass: 3, fail: 0, duration: 1ms]
✔ redirect "pages/acqstack-journeymap" to "acqstack-journeymap.18f.gov" works [pass: 3, fail: 0, duration: 0ms]
✔ redirect "pages/acqstack-journeymap/subpath" to "acqstack-journeymap.18f.gov/subpath" works [pass: 3, fail: 0, duration: 1ms]
✔ redirect "pages/ads-bpa" to "ads.18f.gov" works [pass: 3, fail: 0, duration: 0ms]
✔ redirect "pages/ads-bpa/subpath" to "ads.18f.gov/subpath" works [pass: 3, fail: 0, duration: 0ms]
✔ redirect "pages/agile" to "agile.18f.gov" works [pass: 3, fail: 0, duration: 0ms]
✔ redirect "pages/agile/subpath" to "agile.18f.gov/subpath" works [pass: 3, fail: 0, duration: 1ms]
✔ redirect "pages/api-all-the-x" to "api-all-the-x.18f.gov" works [pass: 3, fail: 0, duration: 0ms]
✔ redirect "pages/api-all-the-x/subpath" to "api-all-the-x.18f.gov/subpath" works [pass: 3, fail: 0, duration: 1ms]
✔ redirect "pages/api-program" to "api-program.18f.gov" works [pass: 3, fail: 0, duration: 0ms]
✔ redirect "pages/api-program/subpath" to "api-program.18f.gov/subpath" works [pass: 3, fail: 0, duration: 1ms]
✔ redirect "pages/api-usability-testing" to "api-usability-testing.18f.gov" works [pass: 3, fail: 0, duration: 0ms]
✔ redirect "pages/api-usability-testing/subpath" to "api-usability-testing.18f.gov/subpath" works [pass: 3, fail: 0, duration: 1ms]
✔ redirect "pages/automated-testing-playbook" to "automated-testing-playbook.18f.gov" works [pass: 3, fail: 0, duration: 1ms]
✔ redirect "pages/automated-testing-playbook/subpath" to "automated-testing-playbook.18f.gov/subpath" works [pass: 3, fail: 0, duration: 0ms]
✔ redirect "pages/before-you-ship" to "before-you-ship.18f.gov" works [pass: 3, fail: 0, duration: 1ms]
✔ redirect "pages/before-you-ship/subpath" to "before-you-ship.18f.gov/subpath" works [pass: 3, fail: 0, duration: 0ms]
✔ redirect "pages/brand" to "brand.18f.gov" works [pass: 3, fail: 0, duration: 1ms]
✔ redirect "pages/brand/subpath" to "brand.18f.gov/subpath" works [pass: 3, fail: 0, duration: 0ms]
✔ redirect "pages/content-guide" to "content-guide.18f.gov" works [pass: 3, fail: 0, duration: 0ms]
✔ redirect "pages/content-guide/subpath" to "content-guide.18f.gov/subpath" works [pass: 3, fail: 0, duration: 1ms]
✔ redirect "pages/contracting-cookbook" to "contracting-cookbook.18f.gov" works [pass: 3, fail: 0, duration: 0ms]
✔ redirect "pages/contracting-cookbook/subpath" to "contracting-cookbook.18f.gov/subpath" works [pass: 3, fail: 0, duration: 1ms]
✔ redirect "pages/design-principles-guide" to "design-principles-guide.18f.gov" works [pass: 3, fail: 0, duration: 0ms]
✔ redirect "pages/design-principles-guide/subpath" to "design-principles-guide.18f.gov/subpath" works [pass: 3, fail: 0, duration: 1ms]
✔ redirect "pages/digitalaccelerator" to "digitalaccelerator.18f.gov" works [pass: 3, fail: 0, duration: 1ms]
✔ redirect "pages/digitalaccelerator/subpath" to "digitalaccelerator.18f.gov/subpath" works [pass: 3, fail: 0, duration: 0ms]
✔ redirect "pages/digital-acquisition-playbook" to "digital-acquisition-playbook.18f.gov" works [pass: 3, fail: 0, duration: 1ms]
✔ redirect "pages/digital-acquisition-playbook/subpath" to "digital-acquisition-playbook.18f.gov/subpath" works [pass: 3, fail: 0, duration: 0ms]
✔ redirect "pages/federalist-modern-team-template" to "federalist-modern-team-template.18f.gov" works [pass: 3, fail: 0, duration: 1ms]
✔ redirect "pages/federalist-modern-team-template/subpath" to "federalist-modern-team-template.18f.gov/subpath" works [pass: 3, fail: 0, duration: 0ms]
✔ redirect "pages/fedspendingtransparency.github.io" to "fedspendingtransparency.18f.gov" works [pass: 3, fail: 0, duration: 0ms]
✔ redirect "pages/fedspendingtransparency.github.io/subpath" to "fedspendingtransparency.18f.gov/subpath" works [pass: 3, fail: 0, duration: 1ms]
✔ redirect "pages/frontend" to "frontend.18f.gov" works [pass: 3, fail: 0, duration: 0ms]
✔ redirect "pages/frontend/subpath" to "frontend.18f.gov/subpath" works [pass: 3, fail: 0, duration: 1ms]
✔ redirect "pages/govconnect" to "govconnect.18f.gov" works [pass: 3, fail: 0, duration: 0ms]
✔ redirect "pages/govconnect/subpath" to "govconnect.18f.gov/subpath" works [pass: 3, fail: 0, duration: 1ms]
✔ redirect "pages/grouplet-playbook" to "grouplet-playbook.18f.gov" works [pass: 3, fail: 0, duration: 0ms]
✔ redirect "pages/grouplet-playbook/subpath" to "grouplet-playbook.18f.gov/subpath" works [pass: 3, fail: 0, duration: 1ms]
✔ redirect "pages/guides-template" to "guides-template.18f.gov" works [pass: 3, fail: 0, duration: 0ms]
✔ redirect "pages/guides-template/subpath" to "guides-template.18f.gov/subpath" works [pass: 3, fail: 0, duration: 1ms]
✔ redirect "pages/iaa-forms" to "iaa-forms.18f.gov" works [pass: 3, fail: 0, duration: 0ms]
✔ redirect "pages/iaa-forms/subpath" to "iaa-forms.18f.gov/subpath" works [pass: 3, fail: 0, duration: 1ms]
✔ redirect "pages/identity-dev-docs" to "developers.login.gov" works [pass: 3, fail: 0, duration: 1ms]
✔ redirect "pages/identity-dev-docs/subpath" to "developers.login.gov/subpath" works [pass: 3, fail: 0, duration: 0ms]
✔ redirect "pages/identity-intro" to "www.login.gov" works [pass: 3, fail: 0, duration: 1ms]
✔ redirect "pages/identity-intro/subpath" to "www.login.gov/subpath" works [pass: 3, fail: 0, duration: 1ms]
✔ redirect "pages/identity-pii-management" to "www.login.gov" works [pass: 3, fail: 0, duration: 0ms]
✔ redirect "pages/identity-pii-management/subpath" to "www.login.gov/security/subpath" works [pass: 3, fail: 0, duration: 1ms]
✔ redirect "pages/identity-playbook" to "www.login.gov" works [pass: 3, fail: 0, duration: 0ms]
✔ redirect "pages/identity-playbook/subpath" to "www.login.gov/playbook/subpath" works [pass: 3, fail: 0, duration: 2ms]
✔ redirect "pages/innovation-toolkit-prototype" to "innovation-toolkit-prototype.18f.gov" works [pass: 3, fail: 0, duration: 1ms]
✔ redirect "pages/innovation-toolkit-prototype/subpath" to "innovation-toolkit-prototype.18f.gov/subpath" works [pass: 3, fail: 0, duration: 0ms]
✔ redirect "pages/lean-product-design" to "lean-product-design.18f.gov" works [pass: 3, fail: 0, duration: 1ms]
✔ redirect "pages/lean-product-design/subpath" to "lean-product-design.18f.gov/subpath" works [pass: 3, fail: 0, duration: 1ms]
✔ redirect "pages/open-source-guide" to "open-source-guide.18f.gov" works [pass: 3, fail: 0, duration: 0ms]
✔ redirect "pages/open-source-guide/subpath" to "open-source-guide.18f.gov/subpath" works [pass: 3, fail: 0, duration: 1ms]
✔ redirect "pages/open-source-program" to "open-source-program.18f.gov" works [pass: 3, fail: 0, duration: 0ms]
✔ redirect "pages/open-source-program/subpath" to "open-source-program.18f.gov/subpath" works [pass: 3, fail: 0, duration: 1ms]
✔ redirect "pages/partnership-playbook" to "partnership-playbook.18f.gov" works [pass: 3, fail: 0, duration: 1ms]
✔ redirect "pages/partnership-playbook/subpath" to "partnership-playbook.18f.gov/subpath" works [pass: 3, fail: 0, duration: 0ms]
✔ redirect "pages/plain-language-tutorial" to "plain-language-tutorial.18f.gov" works [pass: 3, fail: 0, duration: 1ms]
✔ redirect "pages/plain-language-tutorial/subpath" to "plain-language-tutorial.18f.gov/subpath" works [pass: 3, fail: 0, duration: 0ms]
✔ redirect "pages/product-guide" to "product-guide.18f.gov" works [pass: 3, fail: 0, duration: 1ms]
✔ redirect "pages/product-guide/subpath" to "product-guide.18f.gov/subpath" works [pass: 3, fail: 0, duration: 1ms]
✔ redirect "pages/slides" to "slides.18f.gov" works [pass: 3, fail: 0, duration: 1ms]
✔ redirect "pages/slides/subpath" to "slides.18f.gov/subpath" works [pass: 3, fail: 0, duration: 0ms]
✔ redirect "pages/state-faq" to "modularcontracting.18f.gov" works [pass: 3, fail: 0, duration: 0ms]
✔ redirect "pages/state-faq/subpath" to "modularcontracting.18f.gov/subpath" works [pass: 3, fail: 0, duration: 1ms]
✔ redirect "pages/testing-cookbook" to "testing-cookbook.18f.gov" works [pass: 3, fail: 0, duration: 0ms]
✔ redirect "pages/testing-cookbook/subpath" to "testing-cookbook.18f.gov/subpath" works [pass: 3, fail: 0, duration: 1ms]
✔ redirect "pages/writing-lab-guide" to "writing-lab-guide.18f.gov" works [pass: 3, fail: 0, duration: 1ms]
✔ redirect "pages/writing-lab-guide/subpath" to "writing-lab-guide.18f.gov/subpath" works [pass: 3, fail: 0, duration: 0ms]
✔ redirect "pages/demo.pra.digital.gov" to "pra.digital.gov.18f.gov" works [pass: 3, fail: 0, duration: 0ms]
✔ redirect "pages/demo.pra.digital.gov/subpath" to "pra.digital.gov.18f.gov/subpath" works [pass: 3, fail: 0, duration: 1ms]
✔ redirect "pages/identity-intro" to "www.login.gov" [pass: 3, fail: 0, duration: 1ms]
✔ redirect "pages/identity-playbook" to "www.login.gov/playbook" [pass: 3, fail: 0, duration: 0ms]
✔ redirect "pages/identity-pii-management" to "www.login.gov/security" [pass: 3, fail: 0, duration: 1ms]
✔ return error page for anything else [pass: 4, fail: 0, duration: 4ms]

# Summary

duration: 113ms
planned: 622
assertions: 622
pass: 622
fail: 0

WARN[0000] /Users/rileydseaburg/Documents/pages-redirects/docker-compose.yml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion 
[+] Stopping 2/2
 ✔ Container pages-redirects-test_client-1  Stopped                                                0.0s 
 ✔ Container pages-redirects-app-1          Stopped                                                0.1s 
 </details>