### PR TITLE
feat: Remove modularcontracting.18f.gov redirect

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,7 +49,6 @@ services:
       - app:digitalaccelerator.18f.gov
       - app:innovation-toolkit-prototype.18f.gov
       - app:open-source-program.18f.gov
-      - app:modularcontracting.18f.gov
       - app:micropurchase.18f.gov
       - app:acqstack-journeymap.18f.gov
       - app:boise.18f.gov

--- a/pages.yml
+++ b/pages.yml
@@ -54,7 +54,5 @@
 - plain-language-tutorial
 - product-guide
 - slides
-- from: state-faq
-  to: modularcontracting
 - testing-cookbook
 - writing-lab-guide


### PR DESCRIPTION
## Changes proposed in this pull request:

- Removes modularcontracting.18f.gov from redirects

## Security considerations

Removes a redirect
