### PR TITLE
fix: update set-pipeline params

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -33,7 +33,7 @@ jobs:
       - get: src
         params:
           #@ if/end env != 'test':
-          params: { depth: 1 }
+          depth: 1
           #@ if/end env == 'test':
           integration_tool: checkout
         trigger: true


### PR DESCRIPTION
## Changes proposed in this pull request:

- Fixes the redirect deploy pipeline by remove the extra params key

## Security considerations

This will allow the pipeline to update and use the more secure node v24 rather than the node v20 it has been stuck on
